### PR TITLE
(do not merge) Example capture of debug logs

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -145,6 +145,7 @@ pub fn main(options: Options) {
         .arg("elm/random")
         .arg("billstclair/elm-xml-eeue56")
         .arg("jorgengranseth/elm-string-format")
+        .arg("elm/parser")
         .arg("--")
         .arg(&elm_json_tests_path)
         // stdio config

--- a/templates/Reporter.elm
+++ b/templates/Reporter.elm
@@ -5,6 +5,7 @@ import Json.Decode exposing (Value)
 
 port restart : (Int -> msg) -> Sub msg
 port incomingResult : (Value -> msg) -> Sub msg
+port incomingLogs : ({runnerId: Int, logs: String} -> msg) -> Sub msg
 port signalFinished : Int -> Cmd msg
 port stdout : String -> Cmd msg
 
@@ -13,6 +14,7 @@ main =
     ElmTestRunner.Reporter.worker
         { restart = restart
         , incomingResult = incomingResult
+        , incomingLogs = incomingLogs
         , stdout = stdout
         , signalFinished = signalFinished
         }

--- a/templates/node_runner.js
+++ b/templates/node_runner.js
@@ -10,6 +10,11 @@ const { Elm } = require("./Runner.elm.js");
 const flags = { initialSeed: {{ initialSeed }}, fuzzRuns: {{ fuzzRuns }} };
 const app = Elm.Runner.init({ flags: flags });
 
+// Redirect console.log to parent port instead
+console.log = (str) => {
+  parentPort.postMessage({ type_: "logs", logs: str + "\n" });
+};
+
 // Communication from Supervisor to Elm runner via port
 parentPort.on("message", (msg) => {
   if (msg.type_ == "askNbTests") {


### PR DESCRIPTION
Example implementation of how to capture debug logs and print them next to the associated error. This implementation do the following things.

In the runner Elm code, replace a "normal" call to the run function by a call that first logs a specific random string pattern as a clear separation marker.

In `node_runner.js` replace the `console.log` function by a call to parent port to send the console logging to supervisor via worker messages. Then in the supervisor do the wiring to transfer those logs to the reporter (with the runner worker id).

In the reporter Elm code, parse the logs to split them at the random string pattern specified before. Finally, we remove the `onResult` stdout printing and instead, in the `onEnd`, we print failures with their associated logs, followed by the summary.

![debug-logs](https://user-images.githubusercontent.com/2905865/79684732-eb3fee80-8233-11ea-8116-e25c383fc67c.png)
