### PR TITLE
Measure runtime duration of tests

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ fn main() {
         .join("packages")
         .join("mpizenberg")
         .join("elm-test-runner")
-        .join("2.0.0");
+        .join("2.0.1");
     let elm_stuff = Path::new("elm").join("elm-stuff");
     std::fs::remove_dir_all(&elm_stuff)
         .unwrap_or_else(|_| println!("Error removing elm/elm-stuff"));

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,3 @@
-use fs_extra;
 use std::path::{Path, PathBuf};
 
 /// Copy the content of the elm/ dir into

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -150,7 +150,7 @@ fn solve_helper<P: AsRef<Path>>(
     let mut deps = deps;
     deps.insert(
         "mpizenberg/elm-test-runner".to_string(),
-        Range::exact((2, 0, 0)),
+        Range::exact((2, 0, 1)),
     );
     let mut solution = solve_deps(&deps, pkg_id.clone(), version)?;
     solution.remove(pkg_id);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -92,8 +92,8 @@ fn parse_content(input: &str) -> IResult<&str, Vec<&str>> {
     let parse_declaration = alt((
         map(parse_type, |_| None),
         map(parse_port, |_| None),
-        map(preceded(parse_header, parse_definition), |x| Some(x)),
-        map(parse_definition, |x| Some(x)),
+        map(preceded(parse_header, parse_definition), Some),
+        map(parse_definition, Some),
     ));
     fold_many0(
         terminated(parse_declaration, ignore_not_code),
@@ -259,7 +259,7 @@ fn multiline_string_literal(input: &str) -> IResult<&str, &str> {
 fn take_till_escape_or_string_end(input: &str) -> IResult<&str, &str> {
     let mut rest = input;
     let mut count = 0;
-    while !rest.is_empty() && !rest.starts_with("\\") && !rest.starts_with("\"\"\"") {
+    while !rest.is_empty() && !rest.starts_with('\\') && !rest.starts_with("\"\"\"") {
         rest = &rest[1..];
         count += 1;
     }

--- a/templates/Reporter.elm
+++ b/templates/Reporter.elm
@@ -7,7 +7,7 @@ import Json.Decode exposing (Value)
 port restart : (Int -> msg) -> Sub msg
 
 
-port incomingResult : (Value -> msg) -> Sub msg
+port incomingResult : ({ duration : Float, result : Value } -> msg) -> Sub msg
 
 
 port signalFinished : { exitCode : Int, testsCount : Int } -> Cmd msg

--- a/templates/Runner.elm
+++ b/templates/Runner.elm
@@ -13,10 +13,10 @@ port askNbTests : (Value -> msg) -> Sub msg
 port sendNbTests : { type_ : String, nbTests : Int } -> Cmd msg
 
 
-port receiveRunTest : (Int -> msg) -> Sub msg
+port receiveRunTest : ({ id : Int, startTime : Float } -> msg) -> Sub msg
 
 
-port sendResult : { type_ : String, id : Int, result : Value } -> Cmd msg
+port sendResult : { type_ : String, id : Int, startTime : Float, result : Value } -> Cmd msg
 
 
 {-| The implementation of this function will be replaced in the generated JS
@@ -58,5 +58,6 @@ main =
             { askNbTests = askNbTests
             , sendNbTests = \nb -> sendNbTests { type_ = "nbTests", nbTests = nb }
             , receiveRunTest = receiveRunTest
-            , sendResult = \id res -> sendResult { type_ = "result", id = id, result = res }
+            , sendResult = \{ id, startTime } res ->
+                sendResult { type_ = "result", id = id, startTime = startTime, result = res }
             }

--- a/templates/node_runner.js
+++ b/templates/node_runner.js
@@ -1,4 +1,5 @@
 const { parentPort } = require("worker_threads");
+const { performance } = require("perf_hooks");
 
 // From templates/polyfills.js
 {{ polyfills }}
@@ -15,7 +16,7 @@ parentPort.on("message", (msg) => {
   if (msg.type_ == "askNbTests") {
     app.ports.askNbTests.send(null);
   } else if (msg.type_ == "runTest") {
-    app.ports.receiveRunTest.send(msg.id);
+    app.ports.receiveRunTest.send({ id: msg.id, startTime: performance.now() });
   } else {
     console.error("Invalid supervisor msg.type_:", msg.type_);
   }
@@ -23,5 +24,8 @@ parentPort.on("message", (msg) => {
 
 // Communication from Elm runner to Supervisor via port
 // Subscribe to outgoing Elm ports defined in templates/Runner.elm
-app.ports.sendResult.subscribe((msg) => parentPort.postMessage(msg));
+app.ports.sendResult.subscribe((msg) => {
+  msg.endTime = performance.now();
+  parentPort.postMessage(msg);
+});
 app.ports.sendNbTests.subscribe((msg) => parentPort.postMessage(msg));


### PR DESCRIPTION
Here is an implementation of the timing measurement of tests. All measures are done on the JS side with `performance.now()`. Both individual test runs and total time spent by the supervisor are measured. The `Reporter.elm` module reports the sum of individual run times of tests, while `node_supervisor.js` reports in STDERR the total time spent by the supervisor since spawned.
```sh
> elm-geometry $ elm-test-rs --workers 2
...

Running 270 tests. To reproduce these results later, run:
elm-test-rs --seed 1287428620 --fuzz 100 (TODO: pass files to reporter)

TEST RUN PASSED

Passed:   270
Failed:   0
Running duration (workers): 16169 ms     <- from Reporter.elm
Running duration (real total): 8332 ms   <- from node_supervisor.js
```
When using `--workers 1` we can see that the overhead due to spawning the worker, message passing between worker/supervisor, and time spent by the reporter are negligible with big test suites using fuzz testing such as elm-geometry.
```sh
> elm-geometry $ elm-test-rs --workers 1
...

Running duration (workers): 12678 ms
Running duration (real total): 12861 ms
```
For a very small test suite however, it represents the majority of the time spent.
```sh
> word-count $ elm-test-rs --workers 1
...

Running duration (workers): 10 ms
Running duration (real total): 109 ms
```