### PR TITLE
Use include_str macro for templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,6 @@ dependencies = [
  "num_cpus",
  "pathdiff",
  "pico-args",
- "varj",
 ]
 
 [[package]]
@@ -123,9 +122,3 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-
-[[package]]
-name = "varj"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3faa0617fbc4e45d02504b977ba6020897f1dba5cfd9dce84e1b76bf027d64f2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ description = "Simple and fast rust alternative to node-test-runner for elm-test
 [dependencies]
 pico-args = "0.3.4"
 glob = "0.3.0"
-varj = "0.1.0"
 miniserde = "0.1.13"
 pathdiff = "0.2.0"
 num_cpus = "1.13.0"

--- a/src/run.rs
+++ b/src/run.rs
@@ -110,6 +110,9 @@ pub fn main(options: Options) {
         .map(|path| elm_project_root.join(path).canonicalize().unwrap())
         .collect();
 
+    // TODO: get rid of elm_test_rs_root.
+    // The content of the elm/ directory should be used either as an elm package,
+    // or embedded in the executable.
     let elm_test_rs_root = crate::utils::elm_test_rs_root().unwrap();
     let source_directories_for_runner: Vec<PathBuf> = test_directories
         .iter()
@@ -167,10 +170,10 @@ pub fn main(options: Options) {
     // Compile all test files
     eprintln!("Compiling all test files ...");
     compile(
-        &tests_root,                        // current_dir
-        &options.compiler,                  // compiler
-        &Path::new("/dev/null").to_owned(), // output
-        module_paths.iter(),                // src
+        &tests_root,       // current_dir
+        &options.compiler, // compiler
+        "/dev/null",       // output
+        &module_paths,     // src
     );
 
     // Find all modules and tests
@@ -197,59 +200,80 @@ pub fn main(options: Options) {
         .collect();
 
     // Generate templated src/Runner.elm
+    #[cfg(unix)]
+    let runner_template = include_str!("../templates/Runner.elm");
+    #[cfg(windows)]
+    let runner_template = include_str!("..\\templates\\Runner.elm");
     create_templated(
-        elm_test_rs_root.join("templates/Runner.elm"), // template
-        tests_root.join("src/Runner.elm"),             // output
-        vec![
-            ("user_imports".to_string(), runner_imports.join("\n")),
-            ("tests".to_string(), runner_tests.join("\n    , ")),
+        runner_template,                           // template
+        tests_root.join("src").join("Runner.elm"), // output
+        &[
+            ("{{ user_imports }}", &runner_imports.join("\n")),
+            ("{{ tests }}", &runner_tests.join("\n    , ")),
         ],
     );
 
     // Compile the src/Runner.elm file into Runner.elm.js
     eprintln!("Compiling the generated templated src/Runner.elm ...");
-    let compiled_elm_file = tests_root.join("js/Runner.elm.js");
+    let compiled_runner = tests_root.join("js").join("Runner.elm.js");
     compile(
-        &tests_root,         // current_dir
-        &options.compiler,   // compiler
-        &compiled_elm_file,  // output
-        &["src/Runner.elm"], // src
+        &tests_root,       // current_dir
+        &options.compiler, // compiler
+        &compiled_runner,  // output
+        &[Path::new("src").join("Runner.elm")],
     );
 
     // Generate the node_runner.js node module embedding the Elm runner
-    let polyfills = std::fs::read_to_string(&elm_test_rs_root.join("templates/node_polyfills.js"))
-        .expect("polyfills.js template missing");
-    let node_runner_path = tests_root.join("js/node_runner.js");
+    #[cfg(unix)]
+    let polyfills = include_str!("../templates/node_polyfills.js");
+    #[cfg(windows)]
+    let polyfills = include_str!("..\\templates\\node_polyfills.js");
+    #[cfg(unix)]
+    let node_runner_template = include_str!("../templates/node_runner.js");
+    #[cfg(windows)]
+    let node_runner_template = include_str!("..\\templates\\node_runner.js");
+    let node_runner_path = tests_root.join("js").join("node_runner.js");
     create_templated(
-        elm_test_rs_root.join("templates/node_runner.js"), // template
-        node_runner_path.clone(),                          // output
-        vec![
-            ("polyfills".to_string(), polyfills.clone()),
-            ("initialSeed".to_string(), options.seed.to_string()),
-            ("fuzzRuns".to_string(), options.fuzz.to_string()),
+        node_runner_template, // template
+        &node_runner_path,    // output
+        &[
+            ("{{ initialSeed }}", &options.seed.to_string()),
+            ("{{ fuzzRuns }}", &options.fuzz.to_string()),
+            ("{{ polyfills }}", polyfills),
         ],
     );
 
     // Compile the Reporter.elm into Reporter.elm.js
     eprintln!("Compiling Reporter.elm.js ...");
-    let compiled_reporter = tests_root.join("js/Reporter.elm.js");
+    #[cfg(unix)]
+    let reporter_template = include_str!("../templates/Reporter.elm");
+    #[cfg(windows)]
+    let reporter_template = include_str!("..\\templates\\Reporter.elm");
+    let reporter_elm_path = tests_root.join("src").join("Reporter.elm");
+    std::fs::write(&reporter_elm_path, reporter_template)
+        .expect("Error writing Reporter.elm to test folder");
+    let compiled_reporter = tests_root.join("js").join("Reporter.elm.js");
     compile(
         &tests_root,        // current_dir
         &options.compiler,  // compiler
         &compiled_reporter, // output
-        &[elm_test_rs_root.join("templates/Reporter.elm")],
+        &[&reporter_elm_path],
     );
 
     // Generate the supervisor Node module
+    #[cfg(unix)]
+    let node_supervisor_template = include_str!("../templates/node_supervisor.js");
+    #[cfg(windows)]
+    let node_supervisor_template = include_str!("..\\templates\\node_supervisor.js");
     create_templated(
-        elm_test_rs_root.join("templates/node_supervisor.js"), // template
-        tests_root.join("js/node_supervisor.js"),              // output
-        vec![
-            ("polyfills".to_string(), polyfills),
-            ("nb_workers".to_string(), options.workers.to_string()),
-            ("initialSeed".to_string(), options.seed.to_string()),
-            ("fuzzRuns".to_string(), options.fuzz.to_string()),
-            ("reporter".to_string(), reporter),
+        node_supervisor_template,                         // template
+        tests_root.join("js").join("node_supervisor.js"), // output
+        &[
+            ("{{ nb_workers }}", &options.workers.to_string()),
+            ("{{ initialSeed }}", &options.seed.to_string()),
+            ("{{ fuzzRuns }}", &options.fuzz.to_string()),
+            ("{{ reporter }}", &reporter),
+            ("{{ polyfills }}", polyfills),
         ],
     );
 
@@ -296,9 +320,10 @@ fn wait_child(child: &mut std::process::Child) -> Option<i32> {
 }
 
 /// Compile an Elm module into a JS file (without --optimized)
-fn compile<P, I, S>(current_dir: P, compiler: &str, output: P, src: I)
+fn compile<P1, P2, I, S>(current_dir: P1, compiler: &str, output: P2, src: I)
 where
-    P: AsRef<Path>,
+    P1: AsRef<Path>,
+    P2: AsRef<Path>,
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
@@ -319,12 +344,10 @@ where
 }
 
 /// Replace the template keys and write result to output file.
-fn create_templated<P: AsRef<Path>>(template: P, output: P, replacements: Vec<(String, String)>) {
-    let template_content = std::fs::read_to_string(template).expect("template missing");
-    let content = varj::parse(&template_content, &replacements.into_iter().collect())
-        .expect("The template does not match with the replacement keys");
-    std::fs::File::create(output)
-        .expect("Unable to create generated file")
-        .write_all(content.as_bytes())
-        .expect("Unable to write to generated file");
+fn create_templated<P: AsRef<Path>>(template: &str, output: P, replacements: &[(&str, &str)]) {
+    let mut output_str = template.to_string();
+    replacements
+        .iter()
+        .for_each(|(from, to)| output_str = output_str.replacen(from, to, 1));
+    std::fs::write(output, output_str).expect("Unable to write to generated file");
 }


### PR DESCRIPTION
- use `include_str!` macro instead of reading from elm-test-rs/templates/.. at execution time
- remove varj dependency, use simple `replacen` instead