### PR TITLE
Remove dependency to tree_sitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bitvec"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ba35e9565969edb811639dbebfe34edc0368e472c5018474c8eb2543397f81"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,9 +76,9 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "cc"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
@@ -82,9 +100,9 @@ checksum = "7477065d45a8fe57167bf3cf8bcd3729b54cfcb81cca49bda2d038ea89ae82ca"
 
 [[package]]
 name = "const_fn"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
+checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "constant_time_eq"
@@ -164,6 +182,7 @@ dependencies = [
  "fs_extra",
  "glob",
  "lazy_static",
+ "nom",
  "num_cpus",
  "pathdiff",
  "pico-args",
@@ -171,8 +190,6 @@ dependencies = [
  "pubgrub-dependency-provider-elm",
  "regex",
  "serde_json",
- "tree-sitter",
- "tree-sitter-elm",
  "ureq",
 ]
 
@@ -200,6 +217,12 @@ name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
+name = "funty"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
 
 [[package]]
 name = "getrandom"
@@ -260,10 +283,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "libc"
-version = "0.2.80"
+name = "lexical-core"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 0.1.10",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "log"
@@ -285,6 +321,18 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "nom"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88034cfd6b4a0d54dd14f4a507eceee36c0b70e5a02236c4e4df571102be17f0"
+dependencies = [
+ "bitvec",
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
 
 [[package]]
 name = "num_cpus"
@@ -349,7 +397,7 @@ dependencies = [
 [[package]]
 name = "pubgrub-dependency-provider-elm"
 version = "0.1.0"
-source = "git+https://github.com/mpizenberg/pubgrub-dependency-provider-elm?branch=master#6124b2df59e8faa4e961cf82aa42f4bf87ca40f0"
+source = "git+https://github.com/mpizenberg/pubgrub-dependency-provider-elm?branch=master#2ac0e915541f08e03a5c33359b050b72fc7610f1"
 dependencies = [
  "pubgrub",
  "rustc-hash",
@@ -388,6 +436,12 @@ checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "redox_syscall"
@@ -563,6 +617,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stdweb"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,14 +673,20 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "syn"
-version = "1.0.52"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1e438504729046a5cfae47f97c30d6d083c7d91d94603efdae3477fc070d4c"
+checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "thiserror"
@@ -703,26 +769,6 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
-
-[[package]]
-name = "tree-sitter"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18dcb776d3affaba6db04d11d645946d34a69b3172e588af96ce9fecd20faac"
-dependencies = [
- "cc",
- "regex",
-]
-
-[[package]]
-name = "tree-sitter-elm"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5babb1f235891bc8ad1cd4a4700f4ce606403df2ee589775eecb370a2306e70"
-dependencies = [
- "cc",
- "tree-sitter",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -901,3 +947,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,15 @@ pico-args = "0.3.4"
 glob = "0.3.0"
 pathdiff = "0.2.0"
 num_cpus = "1.13.0"
-tree-sitter = "0.17.0"
 regex = "1.4.1"
 lazy_static = "1.4.0"
-tree-sitter-elm = "4.3.4"
 # pubgrub-dependency-provider-elm = { path = "../pubgrub-dependency-provider-elm" }
 pubgrub-dependency-provider-elm = { git = "https://github.com/mpizenberg/pubgrub-dependency-provider-elm", branch = "master" }
 serde_json = "1.0.59"
 ureq = "1.5.2"
 dirs = "3.0.1"
 pubgrub = { version = "0.2", features = ["serde"] }
+nom = "6.0.1"
 
 [dev-dependencies]
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,147 +1,337 @@
 #![warn(clippy::pedantic)]
 
-use std::ops::Range;
-use tree_sitter::{Query, Tree};
+use nom::{
+    branch::*, bytes::complete::*, character::complete::*, combinator::*, multi::*, sequence::*, *,
+};
+
+#[derive(Debug)]
+enum Exposing<'a> {
+    All,
+    Many(Vec<&'a str>),
+}
 
 /// Returns potential tests in the module.
-pub fn potential_tests(src: &str) -> Vec<String> {
-    let mut parser = tree_sitter::Parser::new();
-    let language = tree_sitter_elm::language();
-    parser.set_language(language).unwrap();
-    let tree = parser.parse(src, None).unwrap();
-    get_all_exposed_values_query(&tree, src)
-        .into_iter()
-        .map(ToString::to_string)
-        .collect()
+/// Warning: does not support effect modules and definition of operators.
+pub fn potential_tests(src: &str) -> Vec<&str> {
+    alt((parse_file, parse_content))(src)
+        .map(|x| x.1)
+        .unwrap_or_else(|_| vec![])
 }
 
-lazy_static::lazy_static! {
-    static ref EXPOSING_LIST_QUERY: Query = {
-        let query_str = "(module_declaration exposing: (exposing_list) @list)";
-        Query::new(tree_sitter_elm::language(), query_str).unwrap()
-    };
-    static ref DOUBLE_DOT_QUERY: Query = {
-        let query_str = "((left_parenthesis) . (double_dot))";
-        Query::new(tree_sitter_elm::language(), query_str).unwrap()
-    };
-    static ref EXPOSED_VALUE_QUERY: Query = {
-        let query_str = "(exposed_value) @val";
-        Query::new(tree_sitter_elm::language(), query_str).unwrap()
-    };
-    static ref TOP_LEVEL_VALUE_QUERY: Query = {
-        let query_str = "(file (value_declaration . (_ . (_) @name)))";
-        Query::new(tree_sitter_elm::language(), query_str).unwrap()
-    };
+fn parse_file(input: &str) -> IResult<&str, Vec<&str>> {
+    // Parse the module declaration
+    let (input, exposing) = preceded(ignore_not_code, module_declaration)(input)?;
+    if let Exposing::Many(exposed) = exposing {
+        return Ok((input, exposed));
+    }
+
+    // Parse the rest of the file
+    parse_content(input)
 }
 
-fn get_all_exposed_values_query<'a>(tree: &'a Tree, source: &'a str) -> Vec<&'a str> {
-    match get_exposing_src_range(tree) {
-        None => Vec::new(),
-        Some(range) => get_explicit_exposed_values_query(tree, source, range)
-            .unwrap_or_else(|| get_all_top_level_values_query(tree, source)),
+fn module_declaration(input: &str) -> IResult<&str, Exposing> {
+    // port can be a keyword
+    let (input, _) = alt((tag("port"), success("")))(input)?;
+
+    // module keyword potentially surrounded by garbage
+    let (input, _) = delimited(ignore_not_code, tag("module"), ignore_not_code)(input)?;
+
+    // identifier of the module
+    let (input, _) = take_while(is_allowed_in_module_identifier)(input)?;
+
+    // exposing keyword potentially surrounded by garbage
+    let (input, _) = delimited(ignore_not_code, tag("exposing"), ignore_not_code)(input)?;
+
+    // the exposing clause
+    alt((
+        map(double_dot_expose, |_| Exposing::All),
+        map(comma_separated_exposing, Exposing::Many),
+    ))(input)
+}
+
+// ------------------
+// Parsing the exposing
+
+fn comma_separated_exposing(input: &str) -> IResult<&str, Vec<&str>> {
+    let exposed_item = delimited(ignore_not_code, take_exposed_identifier, ignore_not_code);
+    let (input, items) =
+        delimited(tag("("), separated_list1(tag(","), exposed_item), tag(")"))(input)?;
+    let potential_tests_items: Vec<&str> =
+        items.into_iter().filter(|s| is_potential_test(s)).collect();
+    Ok((input, potential_tests_items))
+}
+
+fn is_potential_test(identifier: &str) -> bool {
+    let first_char = identifier.chars().next().unwrap();
+    first_char.is_lowercase()
+}
+
+fn take_exposed_identifier(input: &str) -> IResult<&str, &str> {
+    let (input, identifier) = take_identifier(input)?;
+    let (input, _) = ignore_not_code(input)?;
+    let (input, _) = alt((double_dot_expose, success("")))(input)?;
+    Ok((input, identifier))
+}
+
+fn double_dot_expose(input: &str) -> IResult<&str, &str> {
+    delimited(
+        preceded(tag("("), ignore_not_code),
+        tag(".."),
+        terminated(ignore_not_code, tag(")")),
+    )(input)
+}
+
+// ------------------
+// Parsing the content
+
+fn parse_content(input: &str) -> IResult<&str, Vec<&str>> {
+    // Parse and ignore all imports
+    let (input, _) = ignore_not_code(input)?;
+    let ignore_import = terminated(parse_import, ignore_not_code);
+    let (input, _) = fold_many0(ignore_import, (), |_, _| ())(input)?;
+
+    // Parse definitions
+    let parse_declaration = alt((
+        map(parse_type, |_| None),
+        map(parse_port, |_| None),
+        map(preceded(parse_header, parse_definition), |x| Some(x)),
+        map(parse_definition, |x| Some(x)),
+    ));
+    fold_many0(
+        terminated(parse_declaration, ignore_not_code),
+        Vec::new(),
+        |mut acc: Vec<&str>, item| {
+            if let Some(decl) = item {
+                acc.push(decl);
+            }
+            acc
+        },
+    )(input)
+}
+
+fn parse_import(input: &str) -> IResult<&str, ()> {
+    let (input, _) = terminated(tag("import"), ignore_not_code)(input)?;
+    let (input, _) = take_body(input)?;
+    Ok((input, ()))
+}
+
+fn parse_type(input: &str) -> IResult<&str, ()> {
+    let (input, _) = terminated(tag("type"), ignore_not_code)(input)?;
+    let (input, _) = take_body(input)?;
+    Ok((input, ()))
+}
+
+fn parse_port(input: &str) -> IResult<&str, &str> {
+    let (input, _) = tag("port")(input)?;
+    let (input, _) = space_or_comment(input)?;
+
+    let (input, _) = ignore_not_code(input)?;
+
+    // identifier of the variable
+    let (input, identifier) = take_identifier(input)?;
+
+    // take everying until a new line followed by a char that is not a whitespace
+    let (input, _) = take_body(input)?;
+
+    Ok((input, identifier))
+}
+
+fn parse_header(input: &str) -> IResult<&str, &str> {
+    // identifier of the declaration, potentially followed by garbage
+    let (input, identifier) = terminated(take_identifier, ignore_not_code)(input)?;
+
+    // : between identifier and type
+    let (input, _) = terminated(tag(":"), ignore_not_code)(input)?;
+
+    // type
+    let (input, _) = terminated(take_body, ignore_not_code)(input)?;
+
+    Ok((input, identifier))
+}
+
+fn parse_definition(input: &str) -> IResult<&str, &str> {
+    // identifier of the variable
+    let (input, identifier) = terminated(take_identifier, ignore_not_code)(input)?;
+
+    // all the things between identifier and equals sign
+    let (input, _) = terminated(take_until("="), tag("="))(input)?;
+
+    // take everying until a new line followed by a char that is not a whitespace
+    let (input, _) = take_body(input)?;
+
+    Ok((input, identifier))
+}
+
+fn take_identifier(input: &str) -> IResult<&str, &str> {
+    take_while1(is_allowed_in_identifier)(input)
+}
+
+// Things to ignore
+
+fn ignore_not_code(input: &str) -> IResult<&str, ()> {
+    fold_many0(space_or_comment, (), |_, _| ())(input)
+}
+
+fn space_or_comment(input: &str) -> IResult<&str, &str> {
+    alt((space1, line_ending, block_comment, line_comment))(input)
+}
+
+// Handling comments
+
+fn line_comment(input: &str) -> IResult<&str, &str> {
+    preceded(tag("--"), not_line_ending)(input)
+}
+
+fn block_comment(input: &str) -> IResult<&str, &str> {
+    within_recursive("{-", "-}", input)
+}
+
+// Warning, the start or end pattern must not contain the other one.
+fn within_recursive<'a>(start: &'a str, end: &'a str, input: &'a str) -> IResult<&'a str, &'a str> {
+    let (input, _) = tag(start)(input)?;
+    let mut rest = input;
+    let mut open_count = 1;
+    let mut char_count = 0;
+    let start_len = start.len();
+    let end_len = end.len();
+    while open_count > 0 {
+        if rest.is_empty() {
+            // fail
+            return tag("x")("o");
+        } else if rest.starts_with(start) {
+            rest = &rest[start_len..];
+            open_count += 1;
+            char_count += start_len;
+        } else if rest.starts_with(end) {
+            rest = &rest[end_len..];
+            open_count -= 1;
+            char_count += end_len;
+        } else {
+            rest = &rest[1..];
+            char_count += 1;
+        }
+    }
+    Ok((rest, &input[..char_count - end_len]))
+}
+
+// ------------------
+// Char filters
+
+fn is_allowed_in_identifier(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+fn is_allowed_in_module_identifier(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '.'
+}
+
+// ------------------
+// Parse strings
+
+fn char_literal(input: &str) -> IResult<&str, &str> {
+    delimited(
+        char('\''),
+        escaped(take_till1(|c| c == '\\' || c == '\''), '\\', anychar),
+        char('\''),
+    )(input)
+}
+
+fn string_literal(input: &str) -> IResult<&str, &str> {
+    delimited(
+        char('"'),
+        alt((
+            escaped(take_till1(|c| c == '\\' || c == '"'), '\\', anychar),
+            success(""),
+        )),
+        char('"'),
+    )(input)
+}
+
+fn multiline_string_literal(input: &str) -> IResult<&str, &str> {
+    delimited(
+        tag("\"\"\""),
+        alt((
+            escaped(take_till_escape_or_string_end, '\\', anychar),
+            success(""),
+        )),
+        tag("\"\"\""),
+    )(input)
+}
+
+fn take_till_escape_or_string_end(input: &str) -> IResult<&str, &str> {
+    let mut rest = input;
+    let mut count = 0;
+    while !rest.is_empty() && !rest.starts_with("\\") && !rest.starts_with("\"\"\"") {
+        rest = &rest[1..];
+        count += 1;
+    }
+    if count == 0 {
+        tag("x")(rest)
+    } else {
+        Ok((rest, &input[..count]))
     }
 }
 
-fn get_exposing_src_range(tree: &Tree) -> Option<Range<usize>> {
-    tree_sitter::QueryCursor::new()
-        .matches(&EXPOSING_LIST_QUERY, tree.root_node(), |_| &[])
-        .next()
-        .map(|m| m.captures[0].node.byte_range())
+// ------------------
+
+fn take_body(input: &str) -> IResult<&str, ()> {
+    fold_many0(body_element, (), |_, _| ())(input)
 }
 
-fn get_explicit_exposed_values_query<'a>(
-    tree: &'a Tree,
-    source: &'a str,
-    range: Range<usize>,
-) -> Option<Vec<&'a str>> {
-    // Restrict the query cursor search to the exposing list
-    let mut query_cursor = tree_sitter::QueryCursor::new();
-    query_cursor.set_byte_range(range.start, range.end);
-
-    // Check if we have a "exposing (..)"
-    if query_cursor
-        .matches(&DOUBLE_DOT_QUERY, tree.root_node(), |_| &[])
-        .next()
-        .is_some()
-    {
-        return None;
-    }
-
-    // Retrieve all exposed values
-    Some(
-        query_cursor
-            .matches(&EXPOSED_VALUE_QUERY, tree.root_node(), |_| &[])
-            .map(|m| &source[m.captures[0].node.byte_range()])
-            .collect(),
-    )
-}
-
-fn get_all_top_level_values_query<'a>(tree: &'a Tree, source: &'a str) -> Vec<&'a str> {
-    tree_sitter::QueryCursor::new()
-        .matches(&TOP_LEVEL_VALUE_QUERY, tree.root_node(), |_| &[])
-        .map(|m| &source[m.captures[0].node.byte_range()])
-        .collect()
+fn body_element(input: &str) -> IResult<&str, &str> {
+    let forbidden_chars = "'-\"{";
+    alt((
+        preceded(fold_many0(line_ending, (), |_, _| ()), space1),
+        block_comment,
+        line_comment,
+        char_literal,
+        multiline_string_literal,
+        string_literal,
+        map(one_of(forbidden_chars), |_| ""),
+        take_till1(move |c| c == '\n' || forbidden_chars.contains(c)),
+    ))(input)
 }
 
 #[cfg(test)]
 mod tests {
-
-    use tree_sitter::{Parser, Tree};
-
-    fn tree_from_elm(source_code: &str) -> Tree {
-        let mut parser = Parser::new();
-        let language = tree_sitter_elm::language();
-        parser.set_language(language).unwrap();
-        parser.parse(source_code, None).unwrap()
-    }
-    #[test]
-    fn smoke() {
-        let source_code = "test : Test.Test";
-        let tree = tree_from_elm(source_code);
-        let root_node = tree.root_node();
-
-        assert_eq!(root_node.kind(), "file");
-        assert_eq!(root_node.start_position().column, 0);
-        assert_eq!(root_node.end_position().column, 16);
-    }
     #[test]
     fn get_explicit_exposed_values() {
-        let helper = |source: &str, expected: &Option<Vec<&str>>| {
-            let tree = tree_from_elm(source);
-            let range = 0..source.len();
-            assert_eq!(
-                super::get_explicit_exposed_values_query(&tree, source, range).as_ref(),
-                expected.as_ref()
-            );
+        let helper = |source: &str, expected: Option<Vec<&str>>| {
+            let exposing = match super::module_declaration(source).unwrap().1 {
+                super::Exposing::All => None,
+                super::Exposing::Many(v) => Some(v),
+            };
+
+            assert_eq!(exposing, expected);
         };
 
-        helper("module Main exposing (..)", &None);
-        helper("module Main.Pain exposing (..)", &None);
-        helper("port module Main.Pain exposing (Int)", &Some(vec![]));
-        helper("port module Main.Pain exposing (int)", &Some(vec!["int"]));
+        helper("module Main exposing (..)", None);
+        helper("module Main.Pain exposing (..)", None);
+        helper("port module Main.Pain exposing (Int)", Some(vec![]));
+        helper("port module Main.Pain exposing (int)", Some(vec!["int"]));
         helper(
             "port module Main.Pain exposing (int, Int, test, Test)",
-            &Some(vec!["int", "test"]),
+            Some(vec!["int", "test"]),
         );
         helper(
             "port module Main.Pain exposing (int, Int, {- -}test, Test)",
-            &Some(vec!["int", "test"]),
+            Some(vec!["int", "test"]),
         );
         helper(
             "port module Main.Pain exposing (int, Int, -- comment
     test, Test)",
-            &Some(vec!["int", "test"]),
+            Some(vec!["int", "test"]),
         );
         helper(
             "port module Main.Pain exposing (int, Int,
     test, Test)",
-            &Some(vec!["int", "test"]),
+            Some(vec!["int", "test"]),
         );
         helper(
             "-- some comment
 module Main.Pain exposing (int, Int,
     test, Test)",
-            &Some(vec!["int", "test"]),
+            Some(vec!["int", "test"]),
         );
         helper(
             r#"
@@ -155,27 +345,24 @@ module{--}Main {-
     ,    three
     )--
 "#,
-            &Some(vec!["one", "two", "three"]),
+            Some(vec!["one", "two", "three"]),
         );
     }
     #[test]
     fn get_all_top_level_values() {
-        let helper = |source: &str, expected: &Vec<&str>| {
-            let tree = tree_from_elm(source);
-            assert_eq!(
-                &super::get_all_top_level_values_query(&tree, source),
-                expected
-            );
+        let helper = |source: &str, expected: Vec<&str>| {
+            let content = super::potential_tests(&source);
+            assert_eq!(content, expected);
         };
 
-        helper("type Test = Thi", &vec![]);
+        helper("type Test = Thi", vec![]);
         helper(
             "test = 3
 differentTest: Test.Test
 differentTest =
     w
 ",
-            &vec!["test", "differentTest"],
+            vec!["test", "differentTest"],
         );
         helper(
             "
@@ -188,7 +375,7 @@ withNestedValues =
     in
     ()
 ",
-            &vec!["withNestedValues"],
+            vec!["withNestedValues"],
         );
         helper(
             "
@@ -201,7 +388,7 @@ withNestedValues a =
     in
     ()
 ",
-            &vec!["withNestedValues"],
+            vec!["withNestedValues"],
         );
         helper(
             r#"
@@ -221,7 +408,7 @@ four{--}=--{-
 five = something
 --}
 "#,
-            &vec!["one", "two", "three", "four", "five"],
+            vec!["one", "two", "three", "four", "five"],
         );
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -151,8 +151,9 @@ pub fn main(options: Options) {
         .map(|(module_name, path)| {
             let source = fs::read_to_string(path).unwrap();
             crate::parser::potential_tests(&source)
-                .into_iter()
+                .iter()
                 .map(move |potential_test| format!("check {}.{}", module_name, potential_test))
+                .collect::<Vec<_>>()
         })
         .flatten()
         .collect();


### PR DESCRIPTION
This PR implements a custom elm parser based on nom that is able to find exposed potential tests, removing the need for tree_sitter. 