### PR TITLE
Port subcommands to pubgrub

### DIFF
--- a/src/deps.rs
+++ b/src/deps.rs
@@ -16,16 +16,16 @@ use pubgrub_dependency_provider_elm::project_config::{
 };
 
 /// Install elm-explorations/test to the tests dependencies.
-pub fn install(config: ProjectConfig) -> Result<ProjectConfig, Box<dyn Error>> {
+pub fn init(config: ProjectConfig) -> Result<ProjectConfig, Box<dyn Error>> {
     match config {
         ProjectConfig::Application(app_config) => {
-            Ok(ProjectConfig::Application(install_app(app_config)?))
+            Ok(ProjectConfig::Application(init_app(app_config)?))
         }
-        ProjectConfig::Package(pkg_config) => Ok(ProjectConfig::Package(install_pkg(pkg_config)?)),
+        ProjectConfig::Package(pkg_config) => Ok(ProjectConfig::Package(init_pkg(pkg_config)?)),
     }
 }
 
-fn install_app(mut app_config: ApplicationConfig) -> Result<ApplicationConfig, Box<dyn Error>> {
+fn init_app(mut app_config: ApplicationConfig) -> Result<ApplicationConfig, Box<dyn Error>> {
     // Retrieve all direct and indirect dependencies
     let indirect_test_deps = app_config.test_dependencies.indirect.iter();
     let mut all_deps: Map<String, Range<SemVer>> = indirect_test_deps
@@ -85,7 +85,7 @@ fn install_app(mut app_config: ApplicationConfig) -> Result<ApplicationConfig, B
     Ok(app_config)
 }
 
-fn install_pkg(mut pkg_config: PackageConfig) -> Result<PackageConfig, Box<dyn Error>> {
+fn init_pkg(mut pkg_config: PackageConfig) -> Result<PackageConfig, Box<dyn Error>> {
     // Retrieve all dependencies
     let test_deps = pkg_config.test_dependencies.iter();
     let mut all_deps: Map<String, Range<SemVer>> = test_deps

--- a/src/init.rs
+++ b/src/init.rs
@@ -2,7 +2,8 @@
 
 use pubgrub_dependency_provider_elm::project_config::ProjectConfig;
 
-/// Use the elm-json binary tool to copy the behavior of the command `elm-test init`.
+/// Add elm-explorations/test to test dependencies
+/// and initialize a template tests/Tests.elm file.
 pub fn main() {
     // Install elm-explorations/test in the tests dependencies
     let elm_json_str = std::fs::read_to_string("elm.json").expect("Unable to read elm.json");

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,30 +1,30 @@
 //! Initialize elm tests.
 
-use std::path::Path;
-use std::process::Command;
+use pubgrub_dependency_provider_elm::project_config::ProjectConfig;
 
 /// Use the elm-json binary tool to copy the behavior of the command `elm-test init`.
 pub fn main() {
-    // Install elm-explorations/test
-    let status = Command::new("elm-json")
-        .arg("install")
-        .arg("--test")
-        .arg("elm-explorations/test@1")
-        .status()
-        .expect("Command elm-json failed to start");
-    if !status.success() {
-        eprintln!(
-            "There was an error when trying to add elm-explorations/test to your dependencies"
-        );
-        std::process::exit(1);
-    }
+    // Install elm-explorations/test in the tests dependencies
+    let elm_json_str = std::fs::read_to_string("elm.json").expect("Unable to read elm.json");
+    let project_config: ProjectConfig = serde_json::from_str(&elm_json_str).unwrap();
+    let updated_config = crate::deps::install(project_config)
+        .expect("Something went wrong when installing elm-explorations/test");
+    std::fs::write(
+        "elm.json",
+        serde_json::to_string_pretty(&updated_config).unwrap(),
+    )
+    .expect("Unable to write to updated elm.json");
 
     // Create the tests/Tests.elm template
+    #[cfg(unix)]
+    let init_tests_template = include_str!("../templates/Tests.elm");
+    #[cfg(windows)]
+    let init_tests_template = include_str!("..\\templates\\Tests.elm");
     std::fs::create_dir_all("tests").expect("Impossible to create directory tests/");
-    let template_path = crate::utils::elm_test_rs_root()
-        .unwrap()
-        .join("templates/Tests.elm");
-    if !Path::new("tests/Tests.elm").exists() {
-        std::fs::copy(template_path, "tests/Tests.elm").expect("Unable to copy Tests.elm template");
+    let new_file_path = std::path::Path::new("tests").join("Tests.elm");
+    if !new_file_path.exists() {
+        std::fs::write(new_file_path, init_tests_template)
+            .expect("Unable to create Tests.elm template");
+        eprintln!("The file test/Tests.elm was created");
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -7,7 +7,7 @@ pub fn main() {
     // Install elm-explorations/test in the tests dependencies
     let elm_json_str = std::fs::read_to_string("elm.json").expect("Unable to read elm.json");
     let project_config: ProjectConfig = serde_json::from_str(&elm_json_str).unwrap();
-    let updated_config = crate::deps::install(project_config)
+    let updated_config = crate::deps::init(project_config)
         .expect("Something went wrong when installing elm-explorations/test");
     std::fs::write(
         "elm.json",

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,17 +1,10 @@
 //! Install packages to test dependencies.
 
-use std::process::Command;
-
-/// Use the binary elm-json to copy behavior of `elm-test install ...`.
+/// Copy behavior of `elm-test install ...`.
 pub fn main(packages: Vec<String>) {
     // Recommend direct usage of elm-json instead
-    println!("Don't hesitate to try zwilias/elm-json directly instead!");
-
-    // Install packages in test dependencies
-    let _ = Command::new("elm-json")
-        .arg("install")
-        .arg("--test")
-        .args(packages)
-        .status()
-        .expect("Command elm-json failed to start");
+    eprintln!("Not implemented.");
+    eprintln!("Please use zwilias/elm-json directly instead.");
+    eprintln!("elm-json install --test {}", packages.join(" "));
+    std::process::exit(1);
 }


### PR DESCRIPTION
Port the `init` subcommand to pubgrub instead of elm-json.
Deactivate the `install` subcommand for now.