### PR TITLE
Add --experimental-worker if using Node 10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 #### Added
 
+- Support Node 10 with `--experimental-worker` option.
+
 #### Changed
 
 #### Removed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Attempt at a simpler alternative to node-test-runner for elm tests.
 Minimum supported version:
 
 - elm 0.19.1
-- Node 12
+- Node 10.5
 
 ## Usage
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -351,10 +351,24 @@ fn main_helper(options: &Options, elm_project_root: &Path, reporter: &str) -> Ve
         ],
     );
 
+    let node_version = Command::new("node")
+        .arg("--version")
+        .output()
+        .expect("command failed to start")
+        .stdout;
+
+    // Node supports worker_threads as experimental feature since 10.5,
+    // but it is unknown whether all versions since 10.5 actually work with elm-test-rs.
+    let mut supervisor_args = Vec::new();
+    if node_version.starts_with(b"v10.") {
+        supervisor_args.push("--experimental-worker");
+    }
+    supervisor_args.push("js/node_supervisor.js");
+
     // Start the tests supervisor
     // eprintln!("Starting the supervisor ...");
     let mut supervisor = Command::new("node")
-        .arg("js/node_supervisor.js")
+        .args(supervisor_args)
         .current_dir(tests_root)
         .stdin(Stdio::piped())
         .spawn()


### PR DESCRIPTION
Fixes #39

I'm not sure whether this should also check if Node is below 10.5 and then exit with error, as those versions are known not to work.

Tested to work in Debian 10 with Node 10.21.0