### PR TITLE
add packaging for nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/osx,elm,vim,node,rust,linux,windows
+
+# nix-build output
+/result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,20 @@
+{ pkgs ? import <nixpkgs> { }, ... }:
+
+let macosDeps = [ pkgs.darwin.apple_sdk.frameworks.CoreServices ];
+in pkgs.rustPlatform.buildRustPackage {
+  pname = "elm-test-rs";
+  version = "0.5.1";
+
+  buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin macosDeps;
+
+  # a nice addition here might be https://github.com/hercules-ci/gitignore.nix to
+  # ignore files from git, which would prevent unnecessary rebuilds. But since
+  # this is just for packaging for now, no need to bother with managing the
+  # dependency!
+  src = ./.;
+
+  # to update this, set the string to all 0's, rebuild, and grab the new hash
+  # that nix gives you
+  cargoSha256 = "1p3fyzs5bkvyvzm5ns3azjb82m5dsafy2c481rxkm00vanadk1mi";
+  verifyCargoDeps = true;
+}

--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,21 @@
 { pkgs ? import <nixpkgs> { }, ... }:
 
+# how to keep this file up to date:
+#
+# 1. keep the `version` in sync with the version in `cargo.toml`. Nothing bad
+#    will happen if you don't do this, but it's nicer to get bug reports
+# 2. rebuild with nix whenever you update `cargo.lock` to get the new
+#    `cargoSha256`. It will give you a more useful error if you replace the hash
+#    with all 0s before building.
+#
+# In the longer term, this file could be submitted to nixpkgs to make it easier
+# for Nix users to install elm-test-rs. That's probably the right move once it
+# hits 1.0.0!
+
 let macosDeps = [ pkgs.darwin.apple_sdk.frameworks.CoreServices ];
 in pkgs.rustPlatform.buildRustPackage {
   pname = "elm-test-rs";
   version = "0.5.1";
-
-  buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin macosDeps;
 
   # a nice addition here might be https://github.com/hercules-ci/gitignore.nix to
   # ignore files from git, which would prevent unnecessary rebuilds. But since
@@ -13,8 +23,8 @@ in pkgs.rustPlatform.buildRustPackage {
   # dependency!
   src = ./.;
 
-  # to update this, set the string to all 0's, rebuild, and grab the new hash
-  # that nix gives you
+  buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin macosDeps;
+
   cargoSha256 = "1p3fyzs5bkvyvzm5ns3azjb82m5dsafy2c481rxkm00vanadk1mi";
   verifyCargoDeps = true;
 }


### PR DESCRIPTION
this adds `nix` packaging for elm-test-rs.

To test this, install Nix (it's available for macOS, but not yet for Big Sur.)  Then run `nix-build`. The binary should show up in `result/bin/elm-test-rs`.