### PR TITLE
Add a --quiet CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 #### Added
 
+- A `--quiet` CLI option. Currently it reduces the amount of stderr logging.
+
 #### Changed
 
 #### Removed

--- a/src/help.rs
+++ b/src/help.rs
@@ -18,13 +18,15 @@ USAGE:
 FLAGS:
     --help                       # Print this message and exit
     --version                    # Print version string and exit
+    --quiet                      # Reduce amount of stderr logs
     --watch                      # Rerun tests on file changes
     --compiler /path/to/compiler # Precise the compiler to use (defaults to just elm)
     --seed integer               # Run with initial fuzzer seed (defaults to random)
     --fuzz integer               # Precise number of iterations of fuzz tests (defaults to 100)
     --workers integer            # Precise number of worker threads (defaults to number of logic cores)
     --filter "substring"         # Keep only the tests whose descriptions contain the given string
-    --report console|json|junit  # Print results to stdout in given the format (defaults to console)
+    --report console|json|junit|exercism
+                                 # Print results to stdout in given the format (defaults to console)
     --connectivity progressive|offline|online-newest|online-oldest
                                  # Connectivity mode (defaults to progessive)
                                  #    offline: elm-test-rs only use installed packages to solve dependencies

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ fn no_subcommand_args(
     Ok(Args::Run(run::Options {
         help: args.contains("--help"),
         version: args.contains("--version"),
+        quiet: args.contains("--quiet"),
         watch: args.contains("--watch"),
         compiler: args
             .opt_value_from_str("--compiler")?


### PR DESCRIPTION
Currently, this reduces the stderr printing. For example, it doesn't print the `elm-test-rs 0.5.1` title or the chosen dependencies to run the tests.