### PR TITLE
Add a --root CLI argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 
 #### Added
 
+- New `--root` CLI option to be able to pass as argument the path to the root
+  of the elm project, containing the `elm.json`.
+
 #### Changed
 
 #### Removed

--- a/src/help.rs
+++ b/src/help.rs
@@ -21,6 +21,7 @@ FLAGS:
     --quiet                      # Reduce amount of stderr logs
     --watch                      # Rerun tests on file changes
     --compiler /path/to/compiler # Precise the compiler to use (defaults to just elm)
+    --root /path/to/elm.json/dir # Precise the path to the root directory of the project (defaults to current dir)
     --seed integer               # Run with initial fuzzer seed (defaults to random)
     --fuzz integer               # Precise number of iterations of fuzz tests (defaults to 100)
     --workers integer            # Precise number of worker threads (defaults to number of logic cores)

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,9 @@ fn no_subcommand_args(
         compiler: args
             .opt_value_from_str("--compiler")?
             .unwrap_or_else(|| "elm".to_string()),
+        root: args
+            .opt_value_from_str("--root")?
+            .unwrap_or_else(|| ".".to_string()),
         seed: args
             .opt_value_from_str("--seed")
             .context("Invalid argument for --seed")?

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,8 @@ fn no_subcommand_args(
         compiler: args
             .opt_value_from_str("--compiler")?
             .unwrap_or_else(|| "elm".to_string()),
-        root: args
-            .opt_value_from_str("--root")?
+        project: args
+            .opt_value_from_str("--project")?
             .unwrap_or_else(|| ".".to_string()),
         seed: args
             .opt_value_from_str("--seed")

--- a/src/run.rs
+++ b/src/run.rs
@@ -24,6 +24,7 @@ pub struct Options {
     pub quiet: bool,
     pub watch: bool,
     pub compiler: String,
+    pub root: String,
     pub seed: u32,
     pub fuzz: u32,
     pub workers: u32,
@@ -61,7 +62,7 @@ pub fn main(options: Options) -> anyhow::Result<()> {
     }
 
     // Verify that we are in an Elm project
-    let elm_project_root = crate::utils::elm_project_root()?;
+    let elm_project_root = crate::utils::elm_project_root(&options.root)?;
 
     // Validate reporter mode
     let reporter = match options.report.as_ref() {

--- a/src/run.rs
+++ b/src/run.rs
@@ -24,7 +24,7 @@ pub struct Options {
     pub quiet: bool,
     pub watch: bool,
     pub compiler: String,
-    pub root: String,
+    pub project: String,
     pub seed: u32,
     pub fuzz: u32,
     pub workers: u32,
@@ -62,7 +62,7 @@ pub fn main(options: Options) -> anyhow::Result<()> {
     }
 
     // Verify that we are in an Elm project
-    let elm_project_root = crate::utils::elm_project_root(&options.root)?;
+    let elm_project_root = crate::utils::elm_project_root(&options.project)?;
 
     // Validate reporter mode
     let reporter = match options.report.as_ref() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,9 +21,9 @@ macro_rules! include_template {
 }
 
 /// Find the root of the elm project (of current dir).
-pub fn elm_project_root() -> anyhow::Result<PathBuf> {
-    let current_dir = std::env::current_dir()
-        .context("Could not retrieve the path of the current working directory")?;
+pub fn elm_project_root(root: &str) -> anyhow::Result<PathBuf> {
+    let current_dir = std::fs::canonicalize(root)
+        .context("Could not retrieve the path of the project directory")?;
     parent_traversal("elm.json", &current_dir)
         .context("I didn't find any elm.json, are you in an Elm project")
 }


### PR DESCRIPTION
elm-test-rs was already able to pick up an `elm.json` in a parent directory, but not in a subdirectory. You can now run elm-test-rs from outside of the project and add the `--root /path/to/elm.json/directory` option and it should work as if you run `elm-test-rs` from that directory.

This is in response to the following comment: https://discourse.elm-lang.org/t/gathering-feedback-on-elm-test-rs-before-1-0-release/6851/7