### PR TITLE
Use a struct instead of String for package ids (fix dependencies ordering)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ All notable changes to this project will be documented in this file.
   by correct error handling thanks to the `anyhow` crate.
 - Fix some Junit and JSON reports issues.
 - Fix `--compiler` error when using relative paths.
+- Fix the indentation of generated elm.json. Now uses 4 spaces.
+- Fix the order of packages in the elm.json dependencies.
 
 
 ## [0.6.1] - (2021-01-23) [(diff)][diff-0.6.1]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "pubgrub-dependency-provider-elm"
 version = "0.1.0"
-source = "git+https://github.com/mpizenberg/pubgrub-dependency-provider-elm?branch=master#c811be5ff699f7b92f49658590dc21003ffb0239"
+source = "git+https://github.com/mpizenberg/pubgrub-dependency-provider-elm?branch=master#3bf4feb9ceb01ed2ae15ee9b5d88a1dcdcbbf09e"
 dependencies = [
  "pubgrub",
  "rustc-hash",

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -236,13 +236,9 @@ fn solve_helper<P: AsRef<Path>>(
         Range::exact((4, 0, 2)),
     );
     // Add elm/json to the deps since it's used in Runner.elm and Reporter.elm.
-    if !deps.contains_key(&Pkg::new("elm", "json")) {
-        // TODO: maybe not the best way to handle but should work most of the time.
-        deps.insert(
-            Pkg::new("elm", "json"),
-            Range::between((1, 0, 0), (2, 0, 0)),
-        );
-    }
+    // TODO: maybe not the best way to handle but should work most of the time.
+    deps.entry(Pkg::new("elm", "json"))
+        .or_insert_with(|| Range::between((1, 0, 0), (2, 0, 0)));
     let mut solution = solve_deps(elm_home, connectivity, &deps, pkg_id.clone(), version)
         .context("Combining the project dependencies with the ones of the test runner failed")?;
     solution.remove(pkg_id);


### PR DESCRIPTION
This effectively changes the order in which packages are sorted.
A struct with the fields { author: String, pkg: String } will sort
"elm/..." earlier than "elm-.../..." whereas the opposite is true
when considering the order of strings.