### PR TITLE
Use the log crate to add multiple verbosity levels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,6 @@ jobs:
             ${{ matrix.target }}-build-
             ${{ matrix.target }}-
 
-      - name: Temporary cache cleaning
-        uses: actions-rs/cargo@v1
-        if: ${{ startsWith(matrix.target, 'x86_64-unknown-linux-musl') }}
-        with:
-          command: clean
-
       - uses: actions-rs/cargo@v1
         with:
           command: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
             ${{ matrix.target }}-build-
             ${{ matrix.target }}-
 
+      - name: Temporary cache cleaning
+        uses: actions-rs/cargo@v1
+        if: ${{ startsWith(matrix.target, 'x86_64-unknown-linux-musl') }}
+        with:
+          command: clean
+
       - uses: actions-rs/cargo@v1
         with:
           command: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this project will be documented in this file.
 - Http timeouts are increased from 1s to 10s.
 - Updated the Elm submodule for the test runner.
 - Changed the CLI crate from pico_args to clap.
+- Replace the `--quiet` flag by a multiple verbosity one `-v`.
+  Level 0 (default) hast mostly quiet stderr, level 3 `-vvv` add debug info,
+  and levels in between add more and more info.
 
 #### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +85,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "chunked_transfer"
@@ -128,6 +147,7 @@ dependencies = [
  "dirs-next",
  "fs_extra",
  "glob",
+ "log",
  "nom",
  "notify",
  "num_cpus",
@@ -137,6 +157,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "stderrlog",
  "ureq",
 ]
 
@@ -333,11 +354,11 @@ checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "log"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -434,6 +455,25 @@ dependencies = [
  "mio-extras",
  "walkdir",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -657,6 +697,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stderrlog"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a53e2eff3e94a019afa6265e8ee04cb05b9d33fe9f5078b14e4e391d155a38"
+dependencies = [
+ "atty",
+ "chrono",
+ "log",
+ "termcolor",
+ "thread_local",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +725,15 @@ name = "tap"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "textwrap"
@@ -704,11 +766,21 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301bdd13d23c49672926be451130892d274d3ba0b410c18e00daa7990ff38d99"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
- "once_cell",
+ "lazy_static",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ atty = "0.2.14"
 anyhow = "1.0.38"
 clap = { version = "2.33.3", default-features = false }
 serde = { version = "1.0.123", default-features = false }
+log = { version = "0.4.14", default-features = false }
+stderrlog = { version = "0.5.1", default-features = false }
 
 [dev-dependencies]
 

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -86,8 +86,8 @@ fn init_app(
             .indirect
             .contains_key(&test_pkg)
         {
-            eprintln!("elm-explorations/test is already in your indirect test dependencies,");
-            eprintln!("so we just upgrade it to a direct test dependency.");
+            log::warn!("elm-explorations/test is already in your indirect test dependencies,");
+            log::warn!("so we just upgrade it to a direct test dependency.");
             let v = app_config
                 .test_dependencies
                 .indirect
@@ -95,12 +95,12 @@ fn init_app(
                 .unwrap(); // this unwrap is fine since we check existence just before.
             app_config.test_dependencies.direct.insert(test_pkg, v);
         } else if app_config.dependencies.indirect.contains_key(&test_pkg) {
-            eprintln!("elm-explorations/test is already in your indirect dependencies,");
-            eprintln!("so we copied the same version in your direct test dependencies.");
+            log::warn!("elm-explorations/test is already in your indirect dependencies,");
+            log::warn!("so we copied the same version in your direct test dependencies.");
             let v = app_config.dependencies.indirect.get(&test_pkg).unwrap(); // this unwrap is fine since we check existence just before.
             app_config.test_dependencies.direct.insert(test_pkg, *v);
         } else {
-            eprintln!("elm-explorations/test is already in your dependencies.");
+            log::warn!("elm-explorations/test is already in your dependencies.");
         }
         return Ok(app_config);
     }
@@ -153,7 +153,7 @@ fn init_pkg(
     // Check if elm-explorations/test is already in the dependencies.
     let test_pkg = Pkg::new("elm-explorations", "test");
     if all_deps.contains_key(&test_pkg) {
-        eprintln!("elm-explorations/test is already in your dependencies.");
+        log::warn!("elm-explorations/test is already in your dependencies.");
         return Ok(pkg_config);
     }
 

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -86,8 +86,8 @@ fn init_app(
             .indirect
             .contains_key(&test_pkg)
         {
-            log::warn!("elm-explorations/test is already in your indirect test dependencies,");
-            log::warn!("so we just upgrade it to a direct test dependency.");
+            log::error!("elm-explorations/test is already in your indirect test dependencies,");
+            log::error!("so we just upgrade it to a direct test dependency.");
             let v = app_config
                 .test_dependencies
                 .indirect
@@ -95,12 +95,12 @@ fn init_app(
                 .unwrap(); // this unwrap is fine since we check existence just before.
             app_config.test_dependencies.direct.insert(test_pkg, v);
         } else if app_config.dependencies.indirect.contains_key(&test_pkg) {
-            log::warn!("elm-explorations/test is already in your indirect dependencies,");
-            log::warn!("so we copied the same version in your direct test dependencies.");
+            log::error!("elm-explorations/test is already in your indirect dependencies,");
+            log::error!("so we copied the same version in your direct test dependencies.");
             let v = app_config.dependencies.indirect.get(&test_pkg).unwrap(); // this unwrap is fine since we check existence just before.
             app_config.test_dependencies.direct.insert(test_pkg, *v);
         } else {
-            log::warn!("elm-explorations/test is already in your dependencies.");
+            log::error!("elm-explorations/test is already in your dependencies.");
         }
         return Ok(app_config);
     }
@@ -153,7 +153,7 @@ fn init_pkg(
     // Check if elm-explorations/test is already in the dependencies.
     let test_pkg = Pkg::new("elm-explorations", "test");
     if all_deps.contains_key(&test_pkg) {
-        log::warn!("elm-explorations/test is already in your dependencies.");
+        log::error!("elm-explorations/test is already in your dependencies.");
         return Ok(pkg_config);
     }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -29,7 +29,7 @@ pub fn main<P: AsRef<Path>>(elm_home: P, project_root: P, offline: bool) -> anyh
     if !new_file_path.exists() {
         std::fs::write(new_file_path, init_tests_template)
             .context("Unable to create Tests.elm template")?;
-        eprintln!("The file tests/Tests.elm was created");
+        log::warn!("The file tests/Tests.elm was created");
     }
     Ok(())
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -29,7 +29,7 @@ pub fn main<P: AsRef<Path>>(elm_home: P, project_root: P, offline: bool) -> anyh
     if !new_file_path.exists() {
         std::fs::write(new_file_path, init_tests_template)
             .context("Unable to create Tests.elm template")?;
-        log::warn!("The file tests/Tests.elm was created");
+        log::error!("The file tests/Tests.elm was created");
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,7 @@ fn get_make_options(arg_matches: &clap::ArgMatches) -> anyhow::Result<make::Opti
         .map(|s| s.to_string())
         .collect();
     Ok(make::Options {
+        verbosity: arg_matches.occurrences_of("verbose"),
         watch: arg_matches.is_present("watch"),
         compiler,
         connectivity,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> anyhow::Result<()> {
             .short("v")
             .multiple(true)
             .global(true)
-            .help("Increase verbosity. Can be used multiple times -vv"),
+            .help("Increase verbosity. Can be used multiple times -vvv"),
     ];
     // Arguments shared with the "make" subcommand.
     let make_args = vec![

--- a/src/make.rs
+++ b/src/make.rs
@@ -17,6 +17,7 @@ use crate::include_template;
 #[derive(Debug)]
 /// Options passed as arguments.
 pub struct Options {
+    pub verbosity: u64,
     pub watch: bool,
     pub compiler: String,
     pub connectivity: crate::deps::ConnectivityStrategy,

--- a/src/run.rs
+++ b/src/run.rs
@@ -32,13 +32,11 @@ pub fn main(
     run_options: Options,
 ) -> anyhow::Result<()> {
     // Prints to stderr the current version
-    if !make_options.quiet {
-        eprintln!(
-            "\nelm-test-rs {} for elm 0.19.1",
-            std::env!("CARGO_PKG_VERSION")
-        );
-        eprintln!("--------------------------------\n");
-    }
+    let title = format!(
+        "elm-test-rs {} for elm 0.19.1",
+        std::env!("CARGO_PKG_VERSION")
+    );
+    log::warn!("\n{}\n{}\n", &title, "-".repeat(title.len()));
 
     if make_options.watch {
         let (mut test_directories, _) =
@@ -63,7 +61,7 @@ pub fn main(
                 notify::DebouncedEvent::NoticeWrite(_) => {}
                 notify::DebouncedEvent::NoticeRemove(_) => {}
                 _event => {
-                    // eprintln!("{:?}", _event);
+                    log::debug!("{:?}", _event);
                     let (new_test_directories, _) =
                         main_helper(elm_home, elm_project_root, &make_options, &run_options)?;
                     if new_test_directories != test_directories {
@@ -125,7 +123,7 @@ fn main_helper(
 
     // Add a kernel patch to the generated code in order to be able to recognize
     // values of type Test at runtime with the `check: a -> Maybe Test` function.
-    // eprintln!("Kernel-patching Runner.elm.js ...");
+    log::info!("Kernel-patching Runner.elm.js ...");
     let compiled_runner_src = fs::read_to_string(&compiled_runner).context(format!(
         "Failed to read newly created file {}",
         compiled_runner.display()
@@ -164,7 +162,7 @@ fn main_helper(
     .context(format!("Failed to write {}", node_runner_path.display()))?;
 
     // Compile the Reporter.elm into Reporter.elm.js
-    // eprintln!("Compiling Reporter.elm.js ...");
+    log::info!("Compiling Reporter.elm.js ...");
     let reporter_template = include_template!("Reporter.elm");
     let reporter_elm_path = tests_root.join("src").join("Reporter.elm");
     std::fs::write(&reporter_elm_path, reporter_template)
@@ -226,7 +224,7 @@ fn main_helper(
     };
 
     // Start the tests supervisor
-    // eprintln!("Starting the supervisor ...");
+    log::info!("Starting the supervisor ...");
     let mut supervisor = Command::new("node")
         .args(experimental_arg)
         .arg(node_supervisor_js_file)
@@ -247,7 +245,7 @@ fn main_helper(
     };
 
     // Send runner module path to supervisor to start the work
-    // eprintln!("Running tests ...");
+    log::info!("Running tests ...");
     let node_runner_path_string = node_runner_path
         .to_str()
         .context(format!(
@@ -272,7 +270,7 @@ fn wait_child(child: &mut std::process::Child) -> Option<i32> {
             _ => None,
         },
         Err(e) => {
-            eprintln!("Error attempting to wait for child: {}", e);
+            log::error!("Error attempting to wait for child: {}", e);
             None
         }
     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -199,6 +199,7 @@ fn main_helper(
             ("{{ initialSeed }}", &run_options.seed.to_string()),
             ("{{ fuzzRuns }}", &run_options.fuzz.to_string()),
             ("{{ reporter }}", &run_options.reporter),
+            ("{{ verbosity }}", &make_options.verbosity.to_string()),
             ("{{ globs }}", &serde_json::to_string(&make_options.files).context("Failed to convert the list of tests files passed as CLI arguments to a JSON list")?),
             ("{{ paths }}", &serde_json::to_string(&modules_abs_paths).context("Failed to convert the list of actual tests files to a JSON list")?),
             ("{{ polyfills }}", polyfills),

--- a/templates/node_supervisor.js
+++ b/templates/node_supervisor.js
@@ -15,6 +15,7 @@ let runners = [];
 let working = false;
 let workersCount = {{ workersCount }};
 const supervisorEvent = new EventEmitter();
+const verbosity = {{ verbosity }};
 
 // Create a long lived reporter worker
 const { Elm } = require("./Reporter.elm.js");
@@ -35,7 +36,9 @@ reporter.ports.signalFinished.subscribe(async ({ exitCode, testsCount }) => {
   await Promise.all(runners.map((runner) => runner.terminate()));
   working = false;
   supervisorEvent.emit("finishedWork");
-  console.error("Running duration (since Node.js start):", Math.round(performance.now()), "ms\n");
+  if (verbosity >= 1) {
+    console.warn("Running duration (since Node.js start):", Math.round(performance.now()), "ms\n");
+  }
   process.exit(exitCode);
 });
 


### PR DESCRIPTION
By default the verbosity level is 0, which corresponds to the smallest output. For the time being, I didn't pass the verbosity level to the reporter, so it only impacts the Rust and JS code.

```sh
$> elm-test-rs

Running 1 tests. To reproduce these results later,
run elm-test-rs with --seed 457886795 and --fuzz 100

◦ TODO: Implement the first test. See https://package.elm-lang.org/packages/elm-explorations/test/latest for how to do this!

TEST RUN INCOMPLETE because there is 1 TODO remaining

Duration: 1 ms
Passed:   0
Failed:   0
Todo:     1
```
Now with verbosity level 1 (`-v`)
```sh
$> elm-test-rs -v

elm-test-rs 1.0.0-beta for elm 0.19.1
-------------------------------------

✓ Compilation of tests modules succeeded

Running 1 tests. To reproduce these results later,
run elm-test-rs with --seed 2836322517 and --fuzz 100

◦ TODO: Implement the first test. See https://package.elm-lang.org/packages/elm-explorations/test/latest for how to do this!

TEST RUN INCOMPLETE because there is 1 TODO remaining

Duration: 1 ms
Passed:   0
Failed:   0
Todo:     1
Running duration (since Node.js start): 87 ms
```
With level 2 (`-vv`)
```sh
$> elm-test-rs -vv

elm-test-rs 1.0.0-beta for elm 0.19.1
-------------------------------------

Generating the elm.json for the Runner.elm
The dependencies picked to run the tests are:
{
  "direct": {
    "elm/core": "1.0.5",
    "elm/json": "1.1.3",
    "elm-explorations/test": "1.2.2",
    "mpizenberg/elm-test-runner": "4.0.3"
  },
  "indirect": {
    "elm/html": "1.0.0",
    "elm/random": "1.0.0",
    "elm/time": "1.0.0",
    "elm/virtual-dom": "1.0.2"
  }
}
Finding all potential tests ...
Spent 0.001879386s generating Runner.elm
Compiling the generated templated src/Runner.elm ...
✓ Compilation of tests modules succeeded
Kernel-patching Runner.elm.js ...
Compiling Reporter.elm.js ...
Starting the supervisor ...
Running tests ...

Running 1 tests. To reproduce these results later,
run elm-test-rs with --seed 1447007600 and --fuzz 100

◦ TODO: Implement the first test. See https://package.elm-lang.org/packages/elm-explorations/test/latest for how to do this!

TEST RUN INCOMPLETE because there is 1 TODO remaining

Duration: 1 ms
Passed:   0
Failed:   0
Todo:     1
Running duration (since Node.js start): 101 ms
```
Level 3 will also add some debugging information.