### PR TITLE
use NonZeroU32 for --fuzz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,6 @@ jobs:
             ${{ matrix.target }}-build-
             ${{ matrix.target }}-
 
-      - name: Temporary cache cleaning
-        uses: actions-rs/cargo@v1
-        if: ${{ startsWith(matrix.target, 'x86_64-unknown-linux-musl') }}
-        with:
-          command: clean
-
       - uses: actions-rs/cargo@v1
         with:
           command: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
             ${{ matrix.target }}-build-
             ${{ matrix.target }}-
 
+      - name: Temporary cache cleaning
+        uses: actions-rs/cargo@v1
+        if: ${{ startsWith(matrix.target, 'x86_64-unknown-linux-musl') }}
+        with:
+          command: clean
+
       - uses: actions-rs/cargo@v1
         with:
           command: build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "pubgrub-dependency-provider-elm"
 version = "0.1.0"
-source = "git+https://github.com/mpizenberg/pubgrub-dependency-provider-elm?branch=master#3bf4feb9ceb01ed2ae15ee9b5d88a1dcdcbbf09e"
+source = "git+https://github.com/mpizenberg/pubgrub-dependency-provider-elm?branch=master#216f0950c1ca2e6991ed63523333aff6bae1e3c7"
 dependencies = [
  "pubgrub",
  "rustc-hash",

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,9 @@ fn get_run_options(arg_matches: &clap::ArgMatches) -> anyhow::Result<run::Option
         Some(str_seed) => str_seed.parse().context("Invalid --seed value")?,
     };
     let str_fuzz = arg_matches.value_of("fuzz").unwrap(); // unwrap is fine since there is a default value
-    let fuzz: NonZeroU32 = str_fuzz.parse().context("Invalid --fuzz value")?;
+    let fuzz: NonZeroU32 = str_fuzz
+        .parse()
+        .context("Invalid --fuzz value. It must be a positive integer.")?;
 
     let workers: u32 = match arg_matches.value_of("workers") {
         None => num_cpus::get() as u32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod utils;
 use anyhow::Context;
 use clap::{App, AppSettings, Arg, SubCommand};
 use pubgrub_dependency_provider_elm::dependency_provider::VersionStrategy;
+use std::num::NonZeroU32;
 
 /// Main entry point of elm-test-rs.
 fn main() -> anyhow::Result<()> {
@@ -207,10 +208,8 @@ fn get_run_options(arg_matches: &clap::ArgMatches) -> anyhow::Result<run::Option
         Some(str_seed) => str_seed.parse().context("Invalid --seed value")?,
     };
     let str_fuzz = arg_matches.value_of("fuzz").unwrap(); // unwrap is fine since there is a default value
-    let fuzz: u32 = str_fuzz.parse().context("Invalid --fuzz value")?;
-    if fuzz == 0 {
-        anyhow::bail!("Invalid --fuzz argument. It must be >= 1");
-    }
+    let fuzz: NonZeroU32 = str_fuzz.parse().context("Invalid --fuzz value")?;
+
     let workers: u32 = match arg_matches.value_of("workers") {
         None => num_cpus::get() as u32,
         Some(str_workers) => str_workers.parse().context("Invalid --workers value")?,

--- a/src/run.rs
+++ b/src/run.rs
@@ -6,6 +6,7 @@ use notify::{watcher, RecursiveMode, Watcher};
 use regex::Regex;
 use std::fs;
 use std::io::Write;
+use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::mpsc::channel;
@@ -17,7 +18,7 @@ use crate::include_template;
 /// Options passed as arguments.
 pub struct Options {
     pub seed: u32,
-    pub fuzz: u32,
+    pub fuzz: NonZeroU32,
     pub workers: u32,
     pub filter: Option<String>,
     pub reporter: String,


### PR DESCRIPTION
Current error message:

```
✦ ❯ elm-test-rs --fuzz 0                                                                                                                                  [19:43:07]
Error: Invalid --fuzz argument. It must be >= 1
```

With this change

```
✦ ❯ elm-test-rs --fuzz 0                                                                                                                                  [19:36:53]
Error: Invalid --fuzz value

Caused by:
    number would be zero for non-zero type
```

I am not sure this is a great improvement. I mainly wanted to "make impossible states impossible".