### PR TITLE
Support Elm project have symlink file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,12 +177,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dunce"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,7 +191,6 @@ dependencies = [
  "atty",
  "clap",
  "dirs-next",
- "dunce",
  "either",
  "fs_extra",
  "glob",
@@ -205,6 +198,7 @@ dependencies = [
  "nom",
  "notify",
  "num_cpus",
+ "path-absolutize",
  "pathdiff",
  "pubgrub",
  "pubgrub-dependency-provider-elm",
@@ -548,6 +542,24 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "path-absolutize"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0feea2f0a6009a0fefe6ee3aae1871e4a57d7f2aae4681ac4a34a201071c9b9"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a14ca47b49e6abd75cf68db85e1e161d9f2b675716894a18af0e9add0266b26"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "pathdiff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ stderrlog = { version = "0.5.1", default-features = false }
 walkdir = "2.3.1" # to find all elm files in a given directory
 either = { version = "1.6.1", default-features = false } # for iterators on two branches
 which = "4.0.2" # to find the path of the elm executable
-dunce = "1.0.1" # to convert Windows UNC paths back to simple absolute paths
+path-absolutize = "3.0.10" # to convert Windows UNC paths back to simple absolute paths
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ stderrlog = { version = "0.5.1", default-features = false }
 walkdir = "2.3.1" # to find all elm files in a given directory
 either = { version = "1.6.1", default-features = false } # for iterators on two branches
 which = "4.0.2" # to find the path of the elm executable
-path-absolutize = "3.0.10" # to convert Windows UNC paths back to simple absolute paths
+path-absolutize = "3.0.10" # simple absolute paths (no Windows UNC)
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 //! Utility functions for the other modules.
 
 use anyhow::Context;
-use path_absolutize::*;
+use path_absolutize::Absolutize;
 use std::error::Error;
 use std::io::Write;
 use std::path::{Path, PathBuf};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 //! Utility functions for the other modules.
 
 use anyhow::Context;
+use path_absolutize::*;
 use std::error::Error;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -101,8 +102,10 @@ pub fn json_write<P: AsRef<Path>, T: ?Sized + serde::Serialize>(
 /// Returns the absolute path with a useful error message if not possible.
 pub fn absolute_path<P: AsRef<Path>>(path: P) -> anyhow::Result<PathBuf> {
     let path = path.as_ref();
-    dunce::canonicalize(path).context(format!(
-        "Error trying to get absolute path of: {}",
-        path.display()
-    ))
+    path.absolutize()
+        .map(PathBuf::from)
+        .context(format!(
+            "Error trying to get absolute path of: {}",
+            path.display()
+        ))
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -102,10 +102,8 @@ pub fn json_write<P: AsRef<Path>, T: ?Sized + serde::Serialize>(
 /// Returns the absolute path with a useful error message if not possible.
 pub fn absolute_path<P: AsRef<Path>>(path: P) -> anyhow::Result<PathBuf> {
     let path = path.as_ref();
-    path.absolutize()
-        .map(PathBuf::from)
-        .context(format!(
-            "Error trying to get absolute path of: {}",
-            path.display()
-        ))
+    path.absolutize().map(PathBuf::from).context(format!(
+        "Error trying to get absolute path of: {}",
+        path.display()
+    ))
 }

--- a/tests/example-projects/passing/symlink/elm.json
+++ b/tests/example-projects/passing/symlink/elm.json
@@ -1,0 +1,1 @@
+../app/elm.json

--- a/tests/example-projects/passing/symlink/src/Main.elm
+++ b/tests/example-projects/passing/symlink/src/Main.elm
@@ -1,0 +1,1 @@
+../../app/src/Main.elm

--- a/tests/example-projects/passing/symlink/tests/Tests.elm
+++ b/tests/example-projects/passing/symlink/tests/Tests.elm
@@ -1,0 +1,1 @@
+../../app/tests/Tests.elm


### PR DESCRIPTION
When use elm-test-rs to Elm project that have symlink file (e.g. `tests/example-projects/passing/symlink`), occur error:

```
elm-test-rs 1.1.0 for elm 0.19.1
--------------------------------

Generating the elm.json for the Runner.elm
The dependencies picked to run the tests are:
{
  "direct": {
    "elm/browser": "1.0.2",
    "elm/core": "1.0.5",
    "elm/html": "1.0.0",
    "elm/json": "1.1.3",
    "elm-explorations/test": "1.2.2",
    "mpizenberg/elm-test-runner": "4.0.5"
  },
  "indirect": {
    "elm/random": "1.0.0",
    "elm/time": "1.0.0",
    "elm/url": "1.0.0",
    "elm/virtual-dom": "1.0.2"
  }
}
get_module_name of: /path/to/elm-test-rs/tests/example-projects/passing/app/tests/Tests.elm
Error: This file "/path/to/elm-test-rs/tests/example-projects/passing/app/tests/Tests.elm" matches no source directory! Imports wont work then.
```

The reason is that `dunce::canonicalize` is not keep symlink when convert to absolute path.
So, use [path-absolutize](https://crates.io/crates/path-absolutize). this crate have function that is return absolute path kept symlink.