### PR TITLE
Add a change detection msg to stderr in --watch

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -131,6 +131,29 @@ impl Project {
                     // Update the current project since dependencies or source directories may have change.
                     *self = new_project;
 
+                    // Log to stderr that a change was detected.
+                    let relative_path = match path {
+                        None => None,
+                        Some(p) => Some(pathdiff::diff_paths(p, &self.root_directory).context(
+                            format!(
+                                "Could not get path {} relative to path {}",
+                                p.display(),
+                                self.root_directory.display()
+                            ),
+                        )?),
+                    };
+                    let detection_msg = format!(
+                        "Change detected in {}",
+                        relative_path
+                            .unwrap_or(PathBuf::from("unknown file"))
+                            .display()
+                    );
+                    log::error!(
+                        "\n\n\n\n{}\n{}\n\n\n\n",
+                        detection_msg,
+                        "=".repeat(detection_msg.len())
+                    );
+
                     // Call the function to execute passed as argument.
                     call_back(self).context("Subsequent run in watch mode")?;
                 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -145,7 +145,7 @@ impl Project {
                     let detection_msg = format!(
                         "Change detected in {}",
                         relative_path
-                            .unwrap_or(PathBuf::from("unknown file"))
+                            .unwrap_or_else(|| PathBuf::from("unknown file"))
                             .display()
                     );
                     log::error!(


### PR DESCRIPTION
This is intended to solve #95 

@Janiczek I opted for the option that does not clear the terminal because it's less clear to me how that plays with the fact that there is both an stdout and stderr stream. So what this does is adding the following message to stderr whenever a change is detected.

```sh
# things of previous run here



Change detected in {path_to_file_here}
======================================



# things of following run here
```

Let me know what you think if you try the binary generated in the CI artifacts.