### PR TITLE
Lamdera compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,7 +622,7 @@ dependencies = [
 [[package]]
 name = "pubgrub-dependency-provider-elm"
 version = "0.1.0"
-source = "git+https://github.com/mpizenberg/pubgrub-dependency-provider-elm?branch=master#216f0950c1ca2e6991ed63523333aff6bae1e3c7"
+source = "git+https://github.com/mpizenberg/pubgrub-dependency-provider-elm?branch=lamdera#85439415e692bc0507de2ffae552b18d94101f88"
 dependencies = [
  "pubgrub",
  "rustc-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,7 +622,7 @@ dependencies = [
 [[package]]
 name = "pubgrub-dependency-provider-elm"
 version = "0.1.0"
-source = "git+https://github.com/mpizenberg/pubgrub-dependency-provider-elm?branch=lamdera#85439415e692bc0507de2ffae552b18d94101f88"
+source = "git+https://github.com/mpizenberg/pubgrub-dependency-provider-elm?rev=a20a795f0#a20a795f0c165517d748566a5d2febbe90ea8d35"
 dependencies = [
  "pubgrub",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ num_cpus = "1.13.0" # to get the number of logic cores
 regex = "1.4.3" # to path the elm kernel code
 pubgrub = { version = "0.2", features = ["serde"] } # for dependency solving
 # pubgrub-dependency-provider-elm = { path = "../pubgrub-dependency-provider-elm" }
-pubgrub-dependency-provider-elm = { git = "https://github.com/mpizenberg/pubgrub-dependency-provider-elm", branch = "lamdera" }
+pubgrub-dependency-provider-elm = { git = "https://github.com/mpizenberg/pubgrub-dependency-provider-elm", rev = "a20a795f0" }
 serde_json = "1.0.61" # for JSON serialization
 serde = { version = "1.0.123", default-features = false }
 ureq = "2.0.1" # for https requests to the package website

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ num_cpus = "1.13.0" # to get the number of logic cores
 regex = "1.4.3" # to path the elm kernel code
 pubgrub = { version = "0.2", features = ["serde"] } # for dependency solving
 # pubgrub-dependency-provider-elm = { path = "../pubgrub-dependency-provider-elm" }
-pubgrub-dependency-provider-elm = { git = "https://github.com/mpizenberg/pubgrub-dependency-provider-elm", branch = "master" }
+pubgrub-dependency-provider-elm = { git = "https://github.com/mpizenberg/pubgrub-dependency-provider-elm", branch = "lamdera" }
 serde_json = "1.0.61" # for JSON serialization
 serde = { version = "1.0.123", default-features = false }
 ureq = "2.0.1" # for https requests to the package website

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -352,6 +352,12 @@ fn solve_deps(
                 Ok(provider) => provider,
                 Err(e) => anyhow::bail!("Failed to initialize the online provider.\n{}", e,),
             };
+            online_provider.save_cache().map_err(|err| {
+                anyhow::anyhow!(
+                    "Failed to save downloaded cache from package website\n{}",
+                    err
+                )
+            })?;
             // TODO: Improve the pubgrub_dependency_provider_elm package to have
             // correctly implemented errors with thiserror.
             let deps_provider =

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -372,6 +372,7 @@ fn solve_deps(
             version,
         )
         .or_else(|_| {
+            log::info!("Solving dependencies in offline mode failed, switching to online mode");
             solve_deps(
                 elm_home,
                 &ConnectivityStrategy::Online(VersionStrategy::Newest),


### PR DESCRIPTION
This update the online dependency provider, which now combines remote and local versions when checking existing versions of a given package.

This should solve lamdera issue with the previous stricter remote-only versions when in online mode mentioned in #104 .

This means that `elm-test-rs` now works normally with lamdera projects, as long as they have at least once called `lamdera make` to download the lamdera-specific packages.