### PR TITLE
Redirect stderr to stdout when --report=json

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,11 @@ Some are small differences:
 - the `console` output isn't exactly the same
 - the `install` command isn't implemented yet (use elm-json for that)
 
-Some might make your tests crash with elm-test-rs.
+Some might make your tests crash with elm-test-rs:
+
+- there is no automatic module description prepended to tests descriptions
+- globs are treated slightly differently
+- the `json` report goes to stdout instead of stderr when erroring.
 
 ### No automatic module description
 
@@ -269,6 +273,13 @@ Whith elm-test, globs support directories so you can call `elm-test tests/` and 
 within the `tests/` directory will be used.
 With elm-test-rs the arguments must be elm files,
 so you would call `elm-test-rs tests/**/*.elm` instead.
+
+### Json report goes to stdout
+
+Since `elm-test-rs` enables multiple levels of verbosity, that additional logging goes to stderr.
+Therefore, to avoid mixing the report output stream and logs, reports go to stdout.
+This applies to reports of running tests as well as potential error reports of compilation.
+In contrast, `elm-test` json report outputs to stdout when running tests, but stderr when compilation fails since it forwards the compiler json output, itself in stderr.
 
 ## Minimum supported version
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,9 @@ fn main() -> anyhow::Result<()> {
             install::main(packages)
         }
         ("make", Some(sub_matches)) => {
-            make::main(&elm_home, &elm_project_root, get_make_options(sub_matches)?)
+            let exit_code =
+                make::main(&elm_home, &elm_project_root, get_make_options(sub_matches)?)?;
+            std::process::exit(exit_code);
         }
         _ => {
             let make_options = get_make_options(&matches)?;

--- a/src/make.rs
+++ b/src/make.rs
@@ -6,6 +6,7 @@ use pubgrub_dependency_provider_elm::project_config::ProjectConfig;
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use walkdir::WalkDir;
@@ -32,7 +33,7 @@ pub struct Options {
 ///  3. Find all tests.
 ///  4. Generate `Runner.elm` with a master test concatenating all found exposed tests.
 ///  5. Compile it.
-pub fn main(elm_home: &Path, elm_project_root: &Path, options: Options) -> anyhow::Result<()> {
+pub fn main(elm_home: &Path, elm_project_root: &Path, options: Options) -> anyhow::Result<i32> {
     // Prints to stderr the current version
     let title = format!(
         "elm-test-rs {} for elm 0.19.1",
@@ -42,11 +43,12 @@ pub fn main(elm_home: &Path, elm_project_root: &Path, options: Options) -> anyho
 
     let mut project = Project::from_dir(elm_project_root.to_path_buf())?;
     if options.watch {
-        project.watch(|proj| main_helper(elm_home, proj, &options).map(|_| ()))
+        project.watch(|proj| main_helper(elm_home, proj, &options).map(|_| ()))?;
+        Ok(0)
     } else {
         match main_helper(elm_home, &project, &options)? {
-            Output::MakeFailure => anyhow::bail!("Compilation failed"),
-            Output::MakeSuccess { .. } => Ok(()),
+            Output::MakeFailure => Ok(1),
+            Output::MakeSuccess { .. } => Ok(0),
         }
     }
 }
@@ -183,16 +185,15 @@ pub fn main_helper(
     log::info!("Spent {}s generating Runner.elm", _preparation_time);
     log::info!("Compiling the generated templated src/Runner.elm ...");
     let compiled_runner = tests_root.join("js").join("Runner.elm.js");
-    if compile(
+    let command = compile(
         elm_home,
         &tests_root,       // current_dir
         &options.compiler, // compiler
         &compiled_runner,  // output
         &options.report,   // report
         &[Path::new("src").join("Runner.elm")],
-    )?
-    .success()
-    {
+    )?;
+    if command.status.success() {
         log::warn!("✓ Compilation of tests modules succeeded");
         Ok(Output::MakeSuccess {
             tests_root,
@@ -200,6 +201,12 @@ pub fn main_helper(
             compiled_runner,
         })
     } else {
+        // Always put the json output of `elm make` to stdout to be consistent
+        // with the fact that the tests runner output also goes to stdout.
+        match options.report.as_str() {
+            "json" => std::io::stdout().write_all(&command.stderr),
+            _ => std::io::stderr().write_all(&command.stderr),
+        }?;
         Ok(Output::MakeFailure)
     }
 }
@@ -266,7 +273,7 @@ pub fn compile<P1, P2, I, S>(
     output: P2,
     report: &str,
     src: I,
-) -> anyhow::Result<std::process::ExitStatus>
+) -> anyhow::Result<std::process::Output>
 where
     P1: AsRef<Path>,
     P2: AsRef<Path>,
@@ -309,6 +316,11 @@ If you installed elm locally with npm, maybe try running with npx such as:
         )
         .context(context_if_fails)
     } else {
+        // Capture compiler output if --report=json.
+        let stderr = match report {
+            "json" => Stdio::piped(),
+            _ => Stdio::inherit(),
+        };
         Command::new(executable)
             .env("ELM_HOME", elm_home)
             .arg("make")
@@ -319,8 +331,8 @@ If you installed elm locally with npm, maybe try running with npx such as:
             // stdio config, comment to see elm make output for debug
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::inherit())
-            .status()
+            .stderr(stderr)
+            .output()
             .context(context_if_fails)
     }
 }
@@ -334,12 +346,17 @@ fn shell_command<I, S>(
     output: &str,
     current_dir: &Path,
     report_arg: Option<&str>,
-) -> Result<std::process::ExitStatus, std::io::Error>
+) -> Result<std::process::Output, std::io::Error>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
     log::debug!("Trying with a cmd shell");
+    // Capture compiler output if --report=json.
+    let stderr = match report {
+        "json" => Stdio::piped(),
+        _ => Stdio::inherit(),
+    };
     Command::new("cmd")
         .env("ELM_HOME", elm_home)
         .arg("/D")
@@ -354,8 +371,8 @@ where
         // stdio config, comment to see elm make output for debug
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::inherit())
-        .status()
+        .stderr(stderr)
+        .output()
 }
 
 /// Fails on unix
@@ -368,12 +385,12 @@ fn shell_command<I, S>(
     output: &str,
     current_dir: &Path,
     report_arg: Option<&str>,
-) -> Result<std::process::ExitStatus, std::io::Error>
+) -> Result<std::process::Output, std::io::Error>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    Command::new(compiler).status()
+    Command::new(compiler).output()
 }
 
 /// Replace the template keys and write result to output file.

--- a/src/make.rs
+++ b/src/make.rs
@@ -297,11 +297,6 @@ If you installed elm locally with npm, maybe try running with npx such as:
         compiler,
         current_dir.as_ref().display()
     );
-    // Transform the --report argument into an argument for the elm compiler.
-    let report_arg = match report {
-        "json" => Some("--report=json"),
-        _ => None,
-    };
     let executable = which::CanonicalPath::new(compiler).context(context_if_fails.clone())?;
     let executable = executable.as_path();
     log::debug!("We found an executable: {}", executable.display());
@@ -312,10 +307,15 @@ If you installed elm locally with npm, maybe try running with npx such as:
             src,
             output,
             current_dir.as_ref(),
-            report_arg,
+            report,
         )
         .context(context_if_fails)
     } else {
+        // Transform the --report argument into an argument for the elm compiler.
+        let report_arg = match report {
+            "json" => Some("--report=json"),
+            _ => None,
+        };
         // Capture compiler output if --report=json.
         let stderr = match report {
             "json" => Stdio::piped(),
@@ -345,13 +345,18 @@ fn shell_command<I, S>(
     src: I,
     output: &str,
     current_dir: &Path,
-    report_arg: Option<&str>,
+    report: &str,
 ) -> Result<std::process::Output, std::io::Error>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
     log::debug!("Trying with a cmd shell");
+    // Transform the --report argument into an argument for the elm compiler.
+    let report_arg = match report {
+        "json" => Some("--report=json"),
+        _ => None,
+    };
     // Capture compiler output if --report=json.
     let stderr = match report {
         "json" => Stdio::piped(),
@@ -384,7 +389,7 @@ fn shell_command<I, S>(
     src: I,
     output: &str,
     current_dir: &Path,
-    report_arg: Option<&str>,
+    report: &str,
 ) -> Result<std::process::Output, std::io::Error>
 where
     I: IntoIterator<Item = S>,

--- a/src/run.rs
+++ b/src/run.rs
@@ -144,16 +144,15 @@ fn main_helper(
         .context("Error writing Reporter.elm to test folder")?;
     let compiled_reporter = tests_root.join("js").join("Reporter.elm.js");
     // let compile_time = std::time::Instant::now();
-    if !crate::make::compile(
+    let command = crate::make::compile(
         elm_home,
         &tests_root,            // current_dir
         &make_options.compiler, // compiler
         &compiled_reporter,     // output
         &make_options.report,   // report
         &[&reporter_elm_path],
-    )?
-    .success()
-    {
+    )?;
+    if !command.status.success() {
         return Ok(1);
     }
 


### PR DESCRIPTION
This PR is related to issue #103.

The objective is to make the output of elm-test-rs consistent over the `make` and `run` (default) sub-commands. Since elm-test-rs enables to display more info related to the command being run with the verbose flag, that information always go to stderr. As a result, elm-test-rs tends to output more stuff to stderr, and I chose to use stdout for the information relevant to the report chosen.

The default report is the console one, intended to be read by people. There it's ok to have stdout and stderr mixed up. But if the report chosen is `json` then elm-test-rs returns the json report to stdout, and everything output to stderr is just information that could be used later by a human to debug problems. So tooling wanting to use the json report should only use the stdout output.

Now the inconsistency was coming from the fact that in contrast, `elm make --report=json` is outputting its report to stderr. And since the elm compiler command is run within elm-test-rs with inherited stdio, the json report from the elm command ended up in the stderr output, mixed with other stderr info output by elm-test-rs.

So in this PR, if the report is `json`, the stderr output of the compiler is captured instead of inherited, and redirected to the stdout output of elm-test-rs.

In sum, for tooling authors, the rule is simple, you only care about the stdout output of elm-test-rs, whether tests pass or fail, and whether it's running or just compiling tests.