### PR TITLE
Remove dependency to stderrlog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,12 +49,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,19 +106,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "chunked_transfer"
@@ -205,7 +186,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "stderrlog",
  "ureq",
  "walkdir",
  "which",
@@ -509,25 +489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,19 +758,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "stderrlog"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a53e2eff3e94a019afa6265e8ee04cb05b9d33fe9f5078b14e4e391d155a38"
-dependencies = [
- "atty",
- "chrono",
- "log",
- "termcolor",
- "thread_local",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,15 +773,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "textwrap"
@@ -862,25 +801,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,7 @@ notify = "4.0.15" # for --watch mode
 atty = "0.2.14" # to handle color correctly in pipes
 anyhow = "1.0.38" # for error handling
 clap = { version = "2.33.3", default-features = false } # for CLI argument parsing
-log = { version = "0.4.14", default-features = false } # for debug logs with -vvv
-stderrlog = { version = "0.5.1", default-features = false }
+log = { version = "0.4.14", default-features = false, features = ["std"] } # for debug logs with -vvv
 walkdir = "2.3.1" # to find all elm files in a given directory
 either = { version = "1.6.1", default-features = false } # for iterators on two branches
 which = "4.0.2" # to find the path of the elm executable

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,27 @@
+//! Simple logger module.
+
+use log::{LevelFilter, Metadata, Record, SetLoggerError};
+
+struct SimpleLogger;
+
+impl log::Log for SimpleLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        println!("{}", record.args());
+    }
+
+    fn flush(&self) {}
+}
+
+pub fn init(verbosity: u64) -> Result<(), SetLoggerError> {
+    let max_level = match verbosity {
+        0 => LevelFilter::Error,
+        1 => LevelFilter::Warn,
+        2 => LevelFilter::Info,
+        _ => LevelFilter::Debug,
+    };
+    log::set_boxed_logger(Box::new(SimpleLogger)).map(|()| log::set_max_level(max_level))
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -10,7 +10,7 @@ impl log::Log for SimpleLogger {
     }
 
     fn log(&self, record: &Record) {
-        println!("{}", record.args());
+        eprintln!("{}", record.args());
     }
 
     fn flush(&self) {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod deps;
 mod init;
 mod install;
+mod logger;
 mod make;
 mod parser;
 mod project;
@@ -142,13 +143,7 @@ fn main() -> anyhow::Result<()> {
 
     // Set log verbosity.
     let verbosity = matches.occurrences_of("verbose");
-    stderrlog::new()
-        .quiet(false)
-        .verbosity(verbosity as usize)
-        .show_level(false)
-        .color(stderrlog::ColorChoice::Never)
-        .init()
-        .context("Failed to initialize log verbosity")?;
+    logger::init(verbosity).context("Failed to initialize logger")?;
 
     match matches.subcommand() {
         ("init", Some(sub_matches)) => init::main(


### PR DESCRIPTION
This solves the current issue that stderrlog depends on Chrono, which currently has the security threat RUSTSEC-2020-0071.

CF https://github.com/cardoe/stderrlog-rs/issues/31