### PR TITLE
Add npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 assets/*.png
 
+# nix-build output
+/result
+
+# npm package binaries
+npm/packages/*/elm-test-rs
+npm/packages/*/elm-test-rs.exe
+
 # Created by https://www.gitignore.io/api/osx,elm,vim,node,rust,linux,windows
 # Edit at https://www.gitignore.io/?templates=osx,elm,vim,node,rust,linux,windows
 
@@ -221,10 +228,3 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/osx,elm,vim,node,rust,linux,windows
-
-# nix-build output
-/result
-
-# npm package binaries
-/packages/*/elm-test-rs
-/packages/*/elm-test-rs.exe

--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,7 @@ $RECYCLE.BIN/
 
 # nix-build output
 /result
+
+# npm package binaries
+/packages/*/elm-test-rs
+/packages/*/elm-test-rs.exe

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ and put it in a directory in your `PATH` environment variable
 so that you can call `elm-test-rs` from anywhere.
 
 To install elm-test-rs **locally** per project,
+either run `npm install elm-test-rs` or
 add elm-test-rs in your `elm-tooling.json` config file
 and use [`elm-tooling install`][elm-tooling].
-In such case, you'll have to run it via npx: `npx elm-test-rs`.
+In both cases, you'll have to run it via npx: `npx elm-test-rs`.
 
 To install elm-test-rs **in your CI**,
 as well as elm and other tools, use this [GitHub action][action].

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,51 @@
+# Creation of a new release
+
+This is taking the 3.0.0 release as an example.
+
+## GitHub stuff
+
+- Update the release date in the changelog and push
+- Check that the tests are passing
+- `git tag -a v3.0 -m "v3.0: Support for the new elm-explorations/test v2"`
+- (Optional) cryptographically sign the tag
+- Push release to github: git push --follow-tags
+- On GitHub, create a release from that tag
+- Include the prebuilt executables from the CI in the GitHub release
+
+The CI builds executables for each supported platform.
+Simply download and unzip all archives (except Windows one) to be left with the `tar.gz` archive.
+Then rename it to follow the already taken convention:
+
+- Linux ARM 32bit: `elm-test-rs_linux-arm-32.tar.gz`
+- Linux ARM 64bit: `elm-test-rs_linux-arm-64.tar.gz`
+- Linux Intel x86 64bit: `elm-test-rs_linux.tar.gz `
+- Apple MacOS ARM 64bit: `elm-test-rs_macos-arm.tar.gz `
+- Apple MacOS Intel x86 64bit: `elm-test-rs_macos.tar.gz`
+- Windows Intel x86 64bit: `elm-test-rs_windows.zip`
+
+## NPM stuff
+
+Repeat this for all the binary packages in `npm/packages/`.
+This uses `npm/packages/elm-test-rs-darwin-x64` as an example.
+
+1. Go to the folder: `cd npm/packages/elm-test-rs-darwin-x64`
+2. Copy the appropriate binary to `./elm-test-rs`. For Windows: `./elm-test-rs.exe`
+3. Double-check that you put the right binary in the right package: `file elm-test-rs`
+4. Double-check that the file is executable: `ls -l elm-test-rs`
+5. In `package.json` of the binary package, bump the version for example to `"3.0.0-0`".
+6. In `package.json` of the main npm package, update `"optionalDependencies"` to point to the bumped version.
+  For example: `"@mpizenberg/elm-test-rs-darwin-x64": "3.0.0-0"`.
+  Note: Pin the versions of the binary packages exactly, no version ranges.
+  This means that installing `elm-test-rs@3.0.0-0` installs the exact same bytes in two years as today.
+7. Publish the package: `npm publish --access=public`
+  `--access=public` is needed because scoped packages are private by default.
+
+Then publish the main npm package by running `npm publish` in the `npm/` folder.
+
+## Crates.io stuff
+
+Maybe one day, with cargo-binstall?
+
+## Community stuff
+
+Talk about the awesome new features of the new release online.

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,5 @@
+# elm-test-rs
+
+Fast and portable executable to run your Elm tests.
+
+👉 [Usage](https://github.com/mpizenberg/elm-test-rs#usage)

--- a/npm/binary.js
+++ b/npm/binary.js
@@ -1,0 +1,86 @@
+var fs = require("fs");
+var path = require("path");
+var package = require("./package.json");
+
+module.exports = function () {
+  var platform = `${process.platform}-${process.arch}`;
+  var subPackageName = `@mpizenberg/elm-test-rs-${platform}`;
+
+  if (!(subPackageName in package.optionalDependencies)) {
+    exitFailure(
+      `The elm-test-rs npm package does not support your platform (${platform}).`
+    );
+  }
+
+  var fileName =
+    process.platform === "win32" ? "elm-test-rs.exe" : "elm-test-rs";
+
+  try {
+    var subBinaryPath = require.resolve(`${subPackageName}/${fileName}`);
+  } catch (error) {
+    if (error && error.code === "MODULE_NOT_FOUND") {
+      exitFailure(missingSubPackageHelp(subPackageName));
+    } else {
+      exitFailure(
+        `I had trouble requiring the binary package for your platform (${subPackageName}):\n\n${error}`
+      );
+    }
+  }
+
+  // Yarn 2 and later ("Berry") always invokes `node` (regardless of configuration)
+  // so we cannot do any optimizations there.
+  var isYarnBerry = /\byarn\/(?!1\.)/.test(
+    process.env.npm_config_user_agent || ""
+  );
+
+  // On Windows, npm always invokes `node` so we cannot do any optimizations there either.
+  if (process.platform === "win32" || isYarnBerry) {
+    return subBinaryPath;
+  }
+
+  var binaryPath = path.resolve(__dirname, package.bin.elm);
+  var tmpPath = binaryPath + ".tmp";
+
+  try {
+    // Atomically replace the file with a hard link to the binary as an optimization.
+    fs.linkSync(subBinaryPath, tmpPath);
+    fs.renameSync(tmpPath, binaryPath);
+  } catch (error) {
+    exitFailure(
+      `I had some trouble writing file to disk. It is saying:\n\n${error}`
+    );
+  }
+
+  return binaryPath;
+};
+
+function exitFailure(message) {
+  console.error(
+    `
+-- ERROR -----------------------------------------------------------------------
+
+${message}
+
+NOTE: You can avoid npm entirely by downloading directly from:
+https://github.com/mpizenberg/elm-test-rs/releases/tag/${package.version}
+All this package does is distributing a file from there.
+
+--------------------------------------------------------------------------------
+    `.trim()
+  );
+  process.exit(1);
+}
+
+function missingSubPackageHelp(subPackageName) {
+  return `
+I support your platform, but I could not find the binary package (${subPackageName}) for it!
+
+This can happen if you use the "--omit=optional" (or "--no-optional") npm flag.
+The "optionalDependencies" package.json feature is used by elm-test-rs to install the correct
+binary executable for your current platform. Remove that flag to use elm-test-rs.
+
+This can also happen if the "node_modules" folder was copied between two operating systems
+that need different binaries - including "virtual" operating systems like Docker and WSL.
+If so, try installing with npm rather than copying "node_modules".
+    `.trim();
+}

--- a/npm/binary.js
+++ b/npm/binary.js
@@ -38,7 +38,7 @@ module.exports = function () {
     return subBinaryPath;
   }
 
-  var binaryPath = path.resolve(__dirname, package.bin.elm);
+  var binaryPath = path.resolve(__dirname, package.bin);
   var tmpPath = binaryPath + ".tmp";
 
   try {

--- a/npm/binary.js
+++ b/npm/binary.js
@@ -4,7 +4,7 @@ var package = require("./package.json");
 
 module.exports = function () {
   var platform = `${process.platform}-${process.arch}`;
-  var subPackageName = `@mpizenberg/elm-test-rs-${platform}`;
+  var subPackageName = `@mattpiz/elm-test-rs-${platform}`;
 
   if (!(subPackageName in package.optionalDependencies)) {
     exitFailure(
@@ -55,7 +55,6 @@ module.exports = function () {
 };
 
 function exitFailure(message) {
-  var tag = `v${package.version.replace(/^(\d+\.\d+)\.0$/, "$1")})}`;
   console.error(
     `
 -- ERROR -----------------------------------------------------------------------
@@ -63,7 +62,7 @@ function exitFailure(message) {
 ${message}
 
 NOTE: You can avoid npm entirely by downloading directly from:
-https://github.com/mpizenberg/elm-test-rs/releases/tag/${tag}
+https://github.com/mpizenberg/elm-test-rs/releases
 All this package does is distributing a file from there.
 
 --------------------------------------------------------------------------------

--- a/npm/binary.js
+++ b/npm/binary.js
@@ -55,6 +55,7 @@ module.exports = function () {
 };
 
 function exitFailure(message) {
+  var tag = `v${package.version.replace(/^(\d+\.\d+)\.0$/, "$1")})}`;
   console.error(
     `
 -- ERROR -----------------------------------------------------------------------
@@ -62,7 +63,7 @@ function exitFailure(message) {
 ${message}
 
 NOTE: You can avoid npm entirely by downloading directly from:
-https://github.com/mpizenberg/elm-test-rs/releases/tag/${package.version}
+https://github.com/mpizenberg/elm-test-rs/releases/tag/${tag}
 All this package does is distributing a file from there.
 
 --------------------------------------------------------------------------------

--- a/npm/elm-test-rs.js
+++ b/npm/elm-test-rs.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+var child_process = require("child_process");
+
+var binaryPath = require("../binary.js")();
+
+child_process
+  .spawn(binaryPath, process.argv.slice(2), { stdio: "inherit" })
+  .on("exit", process.exit);

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,1 @@
+require("./binary.js")();

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "elm-test-rs",
+  "version": "3.0.0",
+  "author": "Matthieu Pizenberg",
+  "license": "BSD-3-Clause",
+  "description": "Fast and portable executable to run your Elm tests.",
+  "repository": "mpizenberg/elm-test-rs",
+  "type": "commonjs",
+  "exports": {},
+  "bin": "./elm-test-rs.js",
+  "keywords": [
+    "elm",
+    "elm-test",
+    "cli",
+    "rust"
+  ],
+  "scripts": {
+    "install": "node install.js"
+  },
+  "optionalDependencies": {
+    "@mpizenberg/elm-test-rs-darwin-arm64": "3.0.0",
+    "@mpizenberg/elm-test-rs-darwin-x64": "3.0.0",
+    "@mpizenberg/elm-test-rs-linux-arm": "3.0.0",
+    "@mpizenberg/elm-test-rs-linux-arm64": "3.0.0",
+    "@mpizenberg/elm-test-rs-linux-x64": "3.0.0",
+    "@mpizenberg/elm-test-rs-win32-x64": "3.0.0"
+  }
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test-rs",
-  "version": "3.0.0-1",
+  "version": "3.0.0-2",
   "author": "Matthieu Pizenberg",
   "license": "BSD-3-Clause",
   "description": "Fast and portable executable to run your Elm tests.",

--- a/npm/package.json
+++ b/npm/package.json
@@ -18,11 +18,11 @@
     "install": "node install.js"
   },
   "optionalDependencies": {
-    "@mpizenberg/elm-test-rs-darwin-arm64": "3.0.0-0",
-    "@mpizenberg/elm-test-rs-darwin-x64": "3.0.0-0",
-    "@mpizenberg/elm-test-rs-linux-arm": "3.0.0-0",
-    "@mpizenberg/elm-test-rs-linux-arm64": "3.0.0-0",
-    "@mpizenberg/elm-test-rs-linux-x64": "3.0.0-0",
-    "@mpizenberg/elm-test-rs-win32-x64": "3.0.0-0"
+    "@mattpiz/elm-test-rs-darwin-arm64": "3.0.0-0",
+    "@mattpiz/elm-test-rs-darwin-x64": "3.0.0-0",
+    "@mattpiz/elm-test-rs-linux-arm": "3.0.0-0",
+    "@mattpiz/elm-test-rs-linux-arm64": "3.0.0-0",
+    "@mattpiz/elm-test-rs-linux-x64": "3.0.0-0",
+    "@mattpiz/elm-test-rs-win32-x64": "3.0.0-0"
   }
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test-rs",
-  "version": "3.0.0-0",
+  "version": "3.0.0-1",
   "author": "Matthieu Pizenberg",
   "license": "BSD-3-Clause",
   "description": "Fast and portable executable to run your Elm tests.",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test-rs",
-  "version": "3.0.0",
+  "version": "3.0.0-0",
   "author": "Matthieu Pizenberg",
   "license": "BSD-3-Clause",
   "description": "Fast and portable executable to run your Elm tests.",
@@ -18,11 +18,11 @@
     "install": "node install.js"
   },
   "optionalDependencies": {
-    "@mpizenberg/elm-test-rs-darwin-arm64": "3.0.0",
-    "@mpizenberg/elm-test-rs-darwin-x64": "3.0.0",
-    "@mpizenberg/elm-test-rs-linux-arm": "3.0.0",
-    "@mpizenberg/elm-test-rs-linux-arm64": "3.0.0",
-    "@mpizenberg/elm-test-rs-linux-x64": "3.0.0",
-    "@mpizenberg/elm-test-rs-win32-x64": "3.0.0"
+    "@mpizenberg/elm-test-rs-darwin-arm64": "3.0.0-0",
+    "@mpizenberg/elm-test-rs-darwin-x64": "3.0.0-0",
+    "@mpizenberg/elm-test-rs-linux-arm": "3.0.0-0",
+    "@mpizenberg/elm-test-rs-linux-arm64": "3.0.0-0",
+    "@mpizenberg/elm-test-rs-linux-x64": "3.0.0-0",
+    "@mpizenberg/elm-test-rs-win32-x64": "3.0.0-0"
   }
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -14,6 +14,7 @@
     "cli",
     "rust"
   ],
+  "files": ["binary.js", "elm-test-rs.js", "install.js"],
   "scripts": {
     "install": "node install.js"
   },

--- a/npm/packages/elm-test-rs-darwin-arm64/README.md
+++ b/npm/packages/elm-test-rs-darwin-arm64/README.md
@@ -1,0 +1,1 @@
+This is the macOS ARM 64-bit binary for [elm-test-rs](https://github.com/mpizenberg/elm-test-rs).

--- a/npm/packages/elm-test-rs-darwin-arm64/package.json
+++ b/npm/packages/elm-test-rs-darwin-arm64/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@mpizenberg/elm-test-rs-darwin-arm64",
+  "version": "3.0.0",
+  "description": "The macOS ARM 64-bit binary for elm-test-rs.",
+  "repository": "https://github.com/mpizenberg/elm-test-rs",
+  "license": "BSD-3-Clause",
+  "os": [ "darwin" ],
+  "cpu": [ "arm64" ]
+}

--- a/npm/packages/elm-test-rs-darwin-arm64/package.json
+++ b/npm/packages/elm-test-rs-darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mpizenberg/elm-test-rs-darwin-arm64",
+  "name": "@mattpiz/elm-test-rs-darwin-arm64",
   "version": "3.0.0-0",
   "description": "The macOS ARM 64-bit binary for elm-test-rs.",
   "repository": "https://github.com/mpizenberg/elm-test-rs",

--- a/npm/packages/elm-test-rs-darwin-arm64/package.json
+++ b/npm/packages/elm-test-rs-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mpizenberg/elm-test-rs-darwin-arm64",
-  "version": "3.0.0",
+  "version": "3.0.0-0",
   "description": "The macOS ARM 64-bit binary for elm-test-rs.",
   "repository": "https://github.com/mpizenberg/elm-test-rs",
   "license": "BSD-3-Clause",

--- a/npm/packages/elm-test-rs-darwin-x64/README.md
+++ b/npm/packages/elm-test-rs-darwin-x64/README.md
@@ -1,0 +1,1 @@
+This is the macOS 64-bit binary for [elm-test-rs](https://github.com/mpizenberg/elm-test-rs).

--- a/npm/packages/elm-test-rs-darwin-x64/package.json
+++ b/npm/packages/elm-test-rs-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mpizenberg/elm-test-rs-darwin-x64",
-  "version": "3.0.0",
+  "version": "3.0.0-0",
   "description": "The macOS 64-bit binary for elm-test-rs.",
   "repository": "https://github.com/mpizenberg/elm-test-rs",
   "license": "BSD-3-Clause",

--- a/npm/packages/elm-test-rs-darwin-x64/package.json
+++ b/npm/packages/elm-test-rs-darwin-x64/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@mpizenberg/elm-test-rs-darwin-x64",
+  "version": "3.0.0",
+  "description": "The macOS 64-bit binary for elm-test-rs.",
+  "repository": "https://github.com/mpizenberg/elm-test-rs",
+  "license": "BSD-3-Clause",
+  "os": [ "darwin" ],
+  "cpu": [ "x64" ]
+}

--- a/npm/packages/elm-test-rs-darwin-x64/package.json
+++ b/npm/packages/elm-test-rs-darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mpizenberg/elm-test-rs-darwin-x64",
+  "name": "@mattpiz/elm-test-rs-darwin-x64",
   "version": "3.0.0-0",
   "description": "The macOS 64-bit binary for elm-test-rs.",
   "repository": "https://github.com/mpizenberg/elm-test-rs",

--- a/npm/packages/elm-test-rs-linux-arm/README.md
+++ b/npm/packages/elm-test-rs-linux-arm/README.md
@@ -1,0 +1,1 @@
+This is the Linux ARM 32-bit binary for [elm-test-rs](https://github.com/mpizenberg/elm-test-rs).

--- a/npm/packages/elm-test-rs-linux-arm/package.json
+++ b/npm/packages/elm-test-rs-linux-arm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mpizenberg/elm-test-rs-linux-arm",
-  "version": "3.0.0",
+  "version": "3.0.0-0",
   "description": "The Linux ARM 32-bit binary for elm-test-rs.",
   "repository": "https://github.com/mpizenberg/elm-test-rs",
   "license": "BSD-3-Clause",

--- a/npm/packages/elm-test-rs-linux-arm/package.json
+++ b/npm/packages/elm-test-rs-linux-arm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mpizenberg/elm-test-rs-linux-arm",
+  "name": "@mattpiz/elm-test-rs-linux-arm",
   "version": "3.0.0-0",
   "description": "The Linux ARM 32-bit binary for elm-test-rs.",
   "repository": "https://github.com/mpizenberg/elm-test-rs",

--- a/npm/packages/elm-test-rs-linux-arm/package.json
+++ b/npm/packages/elm-test-rs-linux-arm/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@mpizenberg/elm-test-rs-linux-arm",
+  "version": "3.0.0",
+  "description": "The Linux ARM 32-bit binary for elm-test-rs.",
+  "repository": "https://github.com/mpizenberg/elm-test-rs",
+  "license": "BSD-3-Clause",
+  "os": [ "linux" ],
+  "cpu": [ "arm" ]
+}

--- a/npm/packages/elm-test-rs-linux-arm64/README.md
+++ b/npm/packages/elm-test-rs-linux-arm64/README.md
@@ -1,0 +1,1 @@
+This is the Linux ARM 64-bit binary for [elm-test-rs](https://github.com/mpizenberg/elm-test-rs).

--- a/npm/packages/elm-test-rs-linux-arm64/package.json
+++ b/npm/packages/elm-test-rs-linux-arm64/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@mpizenberg/elm-test-rs-linux-arm64",
+  "version": "3.0.0",
+  "description": "The Linux ARM 64-bit binary for elm-test-rs.",
+  "repository": "https://github.com/mpizenberg/elm-test-rs",
+  "license": "BSD-3-Clause",
+  "os": [ "linux" ],
+  "cpu": [ "arm64" ]
+}

--- a/npm/packages/elm-test-rs-linux-arm64/package.json
+++ b/npm/packages/elm-test-rs-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mpizenberg/elm-test-rs-linux-arm64",
-  "version": "3.0.0",
+  "version": "3.0.0-0",
   "description": "The Linux ARM 64-bit binary for elm-test-rs.",
   "repository": "https://github.com/mpizenberg/elm-test-rs",
   "license": "BSD-3-Clause",

--- a/npm/packages/elm-test-rs-linux-arm64/package.json
+++ b/npm/packages/elm-test-rs-linux-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mpizenberg/elm-test-rs-linux-arm64",
+  "name": "@mattpiz/elm-test-rs-linux-arm64",
   "version": "3.0.0-0",
   "description": "The Linux ARM 64-bit binary for elm-test-rs.",
   "repository": "https://github.com/mpizenberg/elm-test-rs",

--- a/npm/packages/elm-test-rs-linux-x64/README.md
+++ b/npm/packages/elm-test-rs-linux-x64/README.md
@@ -1,0 +1,1 @@
+This is the Linux 64-bit binary for [elm-test-rs](https://github.com/mpizenberg/elm-test-rs).

--- a/npm/packages/elm-test-rs-linux-x64/package.json
+++ b/npm/packages/elm-test-rs-linux-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mpizenberg/elm-test-rs-linux-x64",
+  "name": "@mattpiz/elm-test-rs-linux-x64",
   "version": "3.0.0-0",
   "description": "The Linux 64-bit binary for elm-test-rs.",
   "repository": "https://github.com/mpizenberg/elm-test-rs",

--- a/npm/packages/elm-test-rs-linux-x64/package.json
+++ b/npm/packages/elm-test-rs-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mpizenberg/elm-test-rs-linux-x64",
-  "version": "3.0.0",
+  "version": "3.0.0-0",
   "description": "The Linux 64-bit binary for elm-test-rs.",
   "repository": "https://github.com/mpizenberg/elm-test-rs",
   "license": "BSD-3-Clause",

--- a/npm/packages/elm-test-rs-linux-x64/package.json
+++ b/npm/packages/elm-test-rs-linux-x64/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@mpizenberg/elm-test-rs-linux-x64",
+  "version": "3.0.0",
+  "description": "The Linux 64-bit binary for elm-test-rs.",
+  "repository": "https://github.com/mpizenberg/elm-test-rs",
+  "license": "BSD-3-Clause",
+  "os": [ "linux" ],
+  "cpu": [ "x64" ]
+}

--- a/npm/packages/elm-test-rs-win32-x64/README.md
+++ b/npm/packages/elm-test-rs-win32-x64/README.md
@@ -1,0 +1,1 @@
+This is the Windows 64-bit binary for [elm-test-rs](https://github.com/mpizenberg/elm-test-rs).

--- a/npm/packages/elm-test-rs-win32-x64/package.json
+++ b/npm/packages/elm-test-rs-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mpizenberg/elm-test-rs-win32-x64",
-  "version": "3.0.0",
+  "version": "3.0.0-0",
   "description": "The Windows 64-bit binary for elm-test-rs.",
   "repository": "https://github.com/mpizenberg/elm-test-rs",
   "license": "BSD-3-Clause",

--- a/npm/packages/elm-test-rs-win32-x64/package.json
+++ b/npm/packages/elm-test-rs-win32-x64/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@mpizenberg/elm-test-rs-win32-x64",
+  "version": "3.0.0",
+  "description": "The Windows 64-bit binary for elm-test-rs.",
+  "repository": "https://github.com/mpizenberg/elm-test-rs",
+  "license": "BSD-3-Clause",
+  "os": [ "win32" ],
+  "cpu": [ "x64" ]
+}

--- a/npm/packages/elm-test-rs-win32-x64/package.json
+++ b/npm/packages/elm-test-rs-win32-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mpizenberg/elm-test-rs-win32-x64",
+  "name": "@mattpiz/elm-test-rs-win32-x64",
   "version": "3.0.0-0",
   "description": "The Windows 64-bit binary for elm-test-rs.",
   "repository": "https://github.com/mpizenberg/elm-test-rs",


### PR DESCRIPTION
This adds a light-weight npm package based on https://github.com/elm/compiler/pull/2287

Here’s how to publish (maybe you want to put this somewhere):

Repeat this for all the binary packages in `packages/`. This uses `packages/elm-test-rs-darwin-x64` as an example.

1. Go to the folder: `cd packages/elm-test-rs-darwin-x64`
1. Copy the appropriate binary to `./elm-test-rs`. For Windows: `./elm-test-rs.exe`
1. Double-check that you put the right binary in the right package: `file elm-test-rs`
1. Double-check that the file is executable: `ls -l elm-test-rs`
1. In `package.json` of the binary package, bump the version for example to `"3.0.1"`.
1. In `package.json` of the main npm package, update `"optionalDependencies"` to point to the bumped version. For example: `"@mpizenberg/elm-test-rs-darwin-x64": "3.0.1"`.

   Note: Pin the versions of the binary packages _exactly_ – no version ranges. This means that installing `elm-test-rs@3.0.1` installs the exact same bytes in two years as today.
1. Publish the package: `npm publish --access=public`

   `--access=public` is needed because scoped packages are private by default.

Then publish the main npm package by running `npm publish` in the `npm/` folder.